### PR TITLE
[Canary 01.5] Module A: Configurable contract constants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build/
 dist/
 artifacts/
 cache/
+deployments/
 __pycache__/
 *.pyc
 attack_runs/

--- a/contracts/PilotEscrow.sol
+++ b/contracts/PilotEscrow.sol
@@ -19,12 +19,12 @@ contract PilotEscrow is Ownable2Step, Pausable, ReentrancyGuard {
 
     uint256 private constant MAX_SCORES = 20;
     // === v1.1.0-rc.1 parameters ===
-    uint256 public constant REQUIRED_ORACLES = 5;
-    uint256 public constant SCORE_QUORUM_PCT = 50;          // BFT majority
-    uint256 public constant PARTICIPATION_FLOOR_PCT = 67;   // supermajority of network must have seen the campaign
+    uint256 public immutable REQUIRED_ORACLES;
+    uint256 public immutable SCORE_QUORUM_PCT;          // BFT majority
+    uint256 public immutable PARTICIPATION_FLOOR_PCT;   // supermajority of network must have seen the campaign
     uint256 public constant PASS_THRESHOLD = 60;
     uint256 public constant MAX_SCORE = 100;
-    uint256 public constant CAMPAIGN_TIMEOUT_BLOCKS = 7200; // ~4h on Base at ~2s blocks
+    uint256 public immutable CAMPAIGN_TIMEOUT_BLOCKS; // ~4h on Base at ~2s blocks
     uint256 public constant CANCEL_FEE_BPS = 100;           // 1% retained on cancel
     uint256 public constant WITHDRAWAL_TIMELOCK = 48 hours;
 
@@ -71,10 +71,32 @@ contract PilotEscrow is Ownable2Step, Pausable, ReentrancyGuard {
     event InsuranceWithdrawalExecuted(address indexed recipient, uint256 amount);
     /// @notice Emitted when the owner cancels a scheduled insurance pool withdrawal.
     event InsuranceWithdrawalCancelled(address indexed recipient);
+    /// @notice Emitted when a campaign close reports an oracle score deviation to the registry.
+    event DeviationReported(bytes32 indexed campaignUid, address indexed oracle, uint256 submittedScore, uint256 medianScore, uint256 deviation);
 
-    constructor(address _registry) Ownable(msg.sender) {
+    constructor(
+        address _registry,
+        uint256 _requiredOracles,
+        uint256 _scoreQuorumPct,
+        uint256 _participationFloorPct,
+        uint256 _campaignTimeoutBlocks
+    ) Ownable(msg.sender) {
         require(_registry != address(0), "Zero registry");
+        require(_requiredOracles >= 1 && _requiredOracles <= MAX_SCORES, "Invalid REQUIRED_ORACLES");
+        require(_scoreQuorumPct >= 1 && _scoreQuorumPct <= 100, "Invalid SCORE_QUORUM_PCT");
+        require(
+            _participationFloorPct >= _scoreQuorumPct && _participationFloorPct <= 100,
+            "Invalid PARTICIPATION_FLOOR_PCT"
+        );
+        require(
+            _campaignTimeoutBlocks >= 100 && _campaignTimeoutBlocks <= 50000,
+            "Invalid CAMPAIGN_TIMEOUT_BLOCKS"
+        );
         registry = VenomRegistry(_registry);
+        REQUIRED_ORACLES = _requiredOracles;
+        SCORE_QUORUM_PCT = _scoreQuorumPct;
+        PARTICIPATION_FLOOR_PCT = _participationFloorPct;
+        CAMPAIGN_TIMEOUT_BLOCKS = _campaignTimeoutBlocks;
     }
 
     function domainSeparator() public view returns (bytes32) {
@@ -166,6 +188,7 @@ contract PilotEscrow is Ownable2Step, Pausable, ReentrancyGuard {
                 ? validScores[i] - medianScore
                 : medianScore - validScores[i];
             if (deviation > maxDeviation) {
+                emit DeviationReported(campaignUid, validSigners[i], validScores[i], medianScore, deviation);
                 registry.reportDeviation(validSigners[i], validScores[i], medianScore);
             }
         }
@@ -269,10 +292,20 @@ contract PilotEscrow is Ownable2Step, Pausable, ReentrancyGuard {
     function _medianOfCopy(uint256[] memory src, uint256 count) internal pure returns (uint256) {
         require(count > 0, "Empty array");
         require(count <= MAX_SCORES, "Too many scores for median");
-        for (uint256 i = 1; i < count; i++) {
-            require(src[i] >= src[i - 1], "Scores not sorted");
+        uint256[] memory sorted = new uint256[](count);
+        for (uint256 i = 0; i < count; i++) {
+            sorted[i] = src[i];
         }
-        return src[count / 2];
+        for (uint256 i = 1; i < count; i++) {
+            uint256 key = sorted[i];
+            uint256 j = i;
+            while (j > 0 && sorted[j - 1] > key) {
+                sorted[j] = sorted[j - 1];
+                j--;
+            }
+            sorted[j] = key;
+        }
+        return sorted[count / 2];
     }
 
     /// @notice Schedule accumulated insurance pool withdrawal.

--- a/contracts/VenomRegistry.sol
+++ b/contracts/VenomRegistry.sol
@@ -43,9 +43,9 @@ contract VenomRegistry is Ownable2Step, ReentrancyGuard {
     address public pendingPilotEscrow;
     uint256 public pendingPilotEscrowScheduledAt;
 
-    uint256 public constant MIN_STAKE = 1 ether;
-    uint256 public constant SLASH_PERCENT = 5; // Reduced for rc.1
-    uint256 public constant MAX_DEVIATION = 25;
+    uint256 public immutable MIN_STAKE;
+    uint256 public immutable SLASH_PERCENT;
+    uint256 public immutable MAX_DEVIATION;
 
     /// @notice Emitted when an operator registers with stake and a Libp2p multiaddr.
     event OracleRegistered(address indexed operator, uint256 stake, string multiaddr);
@@ -70,7 +70,14 @@ contract VenomRegistry is Ownable2Step, ReentrancyGuard {
     /// @notice Emitted when a PilotEscrow upgrade is executed.
     event PilotEscrowUpgraded(address indexed newEscrow);
 
-    constructor() Ownable(msg.sender) {}
+    constructor(uint256 _minStake, uint256 _slashPercent, uint256 _maxDeviation) Ownable(msg.sender) {
+        require(_minStake >= 0.01 ether && _minStake <= 100 ether, "Invalid MIN_STAKE");
+        require(_slashPercent >= 1 && _slashPercent <= 50, "Invalid SLASH_PERCENT");
+        require(_maxDeviation >= 1 && _maxDeviation <= 100, "Invalid MAX_DEVIATION");
+        MIN_STAKE = _minStake;
+        SLASH_PERCENT = _slashPercent;
+        MAX_DEVIATION = _maxDeviation;
+    }
 
     modifier onlyPilotEscrow() {
         require(msg.sender == pilotEscrow, "Only PilotEscrow");

--- a/scripts/deploy_phase4.js
+++ b/scripts/deploy_phase4.js
@@ -9,6 +9,49 @@ const EXPECTED_CHAIN_IDS = Object.freeze({
   "base-sepolia": 84532,
 });
 
+const DEPLOY_PROFILES = Object.freeze({
+  production: {
+    requiredOracles: 5,
+    scoreQuorumPct: 50,
+    participationFloorPct: 67,
+    campaignTimeoutBlocks: 7200,
+    minStakeEth: "1.0",
+    slashPercent: 5,
+    maxDeviation: 25
+  },
+  "canary-01-5": {
+    requiredOracles: 3,
+    scoreQuorumPct: 50,
+    participationFloorPct: 67,
+    campaignTimeoutBlocks: 3600,
+    minStakeEth: "0.1",
+    slashPercent: 5,
+    maxDeviation: 25
+  },
+  solo: {
+    requiredOracles: 1,
+    scoreQuorumPct: 50,
+    participationFloorPct: 67,
+    campaignTimeoutBlocks: 1800,
+    minStakeEth: "0.05",
+    slashPercent: 5,
+    maxDeviation: 25
+  }
+});
+
+function resolveDeployProfile() {
+  const name = process.env.DEPLOY_PROFILE || process.env.CANARY_PROFILE || "production";
+  const profile = DEPLOY_PROFILES[name];
+  if (!profile) {
+    throw new Error(`Unknown deploy profile: ${name}. Valid profiles: ${Object.keys(DEPLOY_PROFILES).join(", ")}`);
+  }
+  return {
+    name,
+    ...profile,
+    minStake: hre.ethers.parseEther(profile.minStakeEth)
+  };
+}
+
 function resolveGitCommit() {
   if (process.env.GIT_COMMIT) return process.env.GIT_COMMIT;
   try {
@@ -49,6 +92,8 @@ async function readWithRetry(description, readFn, isExpected, options = {}) {
 async function main() {
   const [deployer] = await hre.ethers.getSigners();
   console.log("Deploying Phase 4 contracts with account:", deployer.address);
+  const profile = resolveDeployProfile();
+  console.log("Deploy profile:", profile.name);
   const network = await hre.ethers.provider.getNetwork();
   const chainId = Number(network.chainId);
   const expectedChainId = EXPECTED_CHAIN_IDS[hre.network.name];
@@ -59,7 +104,17 @@ async function main() {
 
   // 1. Deploy VenomRegistry
   const VenomRegistry = await hre.ethers.getContractFactory("VenomRegistry");
-  const venomRegistry = await VenomRegistry.deploy();
+  const registryConstructorArguments = [
+    profile.minStake,
+    profile.slashPercent,
+    profile.maxDeviation,
+  ];
+  const registryArtifactArguments = [
+    profile.minStake.toString(),
+    profile.slashPercent,
+    profile.maxDeviation,
+  ];
+  const venomRegistry = await VenomRegistry.deploy(...registryConstructorArguments);
   await venomRegistry.waitForDeployment();
   const venomRegistryAddress = await venomRegistry.getAddress();
   const venomRegistryTx = venomRegistry.deploymentTransaction();
@@ -67,7 +122,14 @@ async function main() {
 
   // 2. Deploy PilotEscrow (passing registry address)
   const PilotEscrow = await hre.ethers.getContractFactory("PilotEscrow");
-  const pilotEscrow = await PilotEscrow.deploy(venomRegistryAddress);
+  const escrowConstructorArguments = [
+    venomRegistryAddress,
+    profile.requiredOracles,
+    profile.scoreQuorumPct,
+    profile.participationFloorPct,
+    profile.campaignTimeoutBlocks,
+  ];
+  const pilotEscrow = await PilotEscrow.deploy(...escrowConstructorArguments);
   await pilotEscrow.waitForDeployment();
   const pilotEscrowAddress = await pilotEscrow.getAddress();
   const pilotEscrowTx = pilotEscrow.deploymentTransaction();
@@ -75,7 +137,8 @@ async function main() {
 
   // 3. Set PilotEscrow in Registry
   const bindTx = await venomRegistry.setPilotEscrow(pilotEscrowAddress);
-  const bindReceipt = await bindTx.wait(3);
+  const bindConfirmations = hre.network.name === "hardhat" ? 1 : 3;
+  const bindReceipt = await bindTx.wait(bindConfirmations);
   console.log("PilotEscrow address set in VenomRegistry");
 
   const boundEscrow = await readWithRetry(
@@ -113,6 +176,18 @@ async function main() {
     gitCommit: resolveGitCommit(),
     deployedAt: new Date().toISOString(),
     deployer: deployer.address,
+    profile: {
+      name: profile.name,
+      constants: {
+        REQUIRED_ORACLES: profile.requiredOracles,
+        SCORE_QUORUM_PCT: profile.scoreQuorumPct,
+        PARTICIPATION_FLOOR_PCT: profile.participationFloorPct,
+        CAMPAIGN_TIMEOUT_BLOCKS: profile.campaignTimeoutBlocks,
+        MIN_STAKE: profile.minStake.toString(),
+        SLASH_PERCENT: profile.slashPercent,
+        MAX_DEVIATION: profile.maxDeviation,
+      },
+    },
     owners: {
       VenomRegistry: registryOwner,
       PilotEscrow: escrowOwner,
@@ -120,12 +195,12 @@ async function main() {
     contracts: {
       VenomRegistry: {
         address: venomRegistryAddress,
-        constructorArguments: [],
+        constructorArguments: registryArtifactArguments,
         deploymentTxHash: venomRegistryTx ? venomRegistryTx.hash : null,
       },
       PilotEscrow: {
         address: pilotEscrowAddress,
-        constructorArguments: [venomRegistryAddress],
+        constructorArguments: escrowConstructorArguments,
         deploymentTxHash: pilotEscrowTx ? pilotEscrowTx.hash : null,
       },
     },
@@ -143,8 +218,8 @@ async function main() {
   fs.writeFileSync(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`);
   console.log("Deployment artifact written to:", artifactPath);
 
-  await maybeVerify(venomRegistryAddress, []);
-  await maybeVerify(pilotEscrowAddress, [venomRegistryAddress]);
+  await maybeVerify(venomRegistryAddress, registryArtifactArguments);
+  await maybeVerify(pilotEscrowAddress, escrowConstructorArguments);
 
   console.log("\n=== Phase 4 Deployment Complete ===");
   console.log("VENOM_REGISTRY_ADDRESS=", venomRegistryAddress);

--- a/test/ConfigurableConstants.test.js
+++ b/test/ConfigurableConstants.test.js
@@ -1,0 +1,122 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+const PRODUCTION_REGISTRY_ARGS = [ethers.parseEther("1.0"), 5, 25];
+const PRODUCTION_ESCROW_ARGS = [5, 50, 67, 7200];
+const CANARY_REGISTRY_ARGS = [ethers.parseEther("0.1"), 5, 25];
+const CANARY_ESCROW_ARGS = [3, 50, 67, 3600];
+
+async function deployRegistry(args = PRODUCTION_REGISTRY_ARGS) {
+  const Registry = await ethers.getContractFactory("VenomRegistry");
+  return Registry.deploy(...args);
+}
+
+async function deployEscrow(registry, args = PRODUCTION_ESCROW_ARGS) {
+  const Escrow = await ethers.getContractFactory("PilotEscrow");
+  return Escrow.deploy(await registry.getAddress(), ...args);
+}
+
+async function signEip712Score(signers, campaignUid, scores, escrowContract) {
+  const net = await ethers.provider.getNetwork();
+  const domain = {
+    name: "VENOM PilotEscrow",
+    version: "1",
+    chainId: Number(net.chainId),
+    verifyingContract: await escrowContract.getAddress()
+  };
+  const types = {
+    Score: [
+      { name: "campaignUid", type: "bytes32" },
+      { name: "score", type: "uint256" }
+    ]
+  };
+  return Promise.all(scores.map((score, index) => {
+    return signers[index].signTypedData(domain, types, { campaignUid, score });
+  }));
+}
+
+async function signEip712Abstain(signers, campaignUid, reasons, escrowContract) {
+  const net = await ethers.provider.getNetwork();
+  const domain = {
+    name: "VENOM PilotEscrow",
+    version: "1",
+    chainId: Number(net.chainId),
+    verifyingContract: await escrowContract.getAddress()
+  };
+  const types = {
+    Abstain: [
+      { name: "campaignUid", type: "bytes32" },
+      { name: "reason", type: "uint8" }
+    ]
+  };
+  return Promise.all(reasons.map((reason, index) => {
+    return signers[index].signTypedData(domain, types, { campaignUid, reason });
+  }));
+}
+
+describe("Configurable deployment constants", function () {
+  it("preserves production profile values through public getters", async function () {
+    const registry = await deployRegistry();
+    const escrow = await deployEscrow(registry);
+
+    expect(await registry.MIN_STAKE()).to.equal(ethers.parseEther("1.0"));
+    expect(await registry.SLASH_PERCENT()).to.equal(5n);
+    expect(await registry.MAX_DEVIATION()).to.equal(25n);
+    expect(await escrow.REQUIRED_ORACLES()).to.equal(5n);
+    expect(await escrow.SCORE_QUORUM_PCT()).to.equal(50n);
+    expect(await escrow.PARTICIPATION_FLOOR_PCT()).to.equal(67n);
+    expect(await escrow.CAMPAIGN_TIMEOUT_BLOCKS()).to.equal(7200n);
+  });
+
+  it("rejects invalid registry constructor constants", async function () {
+    const Registry = await ethers.getContractFactory("VenomRegistry");
+
+    await expect(Registry.deploy(ethers.parseEther("0.009"), 5, 25))
+      .to.be.revertedWith("Invalid MIN_STAKE");
+    await expect(Registry.deploy(ethers.parseEther("1.0"), 0, 25))
+      .to.be.revertedWith("Invalid SLASH_PERCENT");
+    await expect(Registry.deploy(ethers.parseEther("1.0"), 5, 0))
+      .to.be.revertedWith("Invalid MAX_DEVIATION");
+  });
+
+  it("rejects invalid escrow constructor constants", async function () {
+    const registry = await deployRegistry();
+    const Escrow = await ethers.getContractFactory("PilotEscrow");
+    const registryAddress = await registry.getAddress();
+
+    await expect(Escrow.deploy(registryAddress, 0, 50, 67, 7200))
+      .to.be.revertedWith("Invalid REQUIRED_ORACLES");
+    await expect(Escrow.deploy(registryAddress, 5, 0, 67, 7200))
+      .to.be.revertedWith("Invalid SCORE_QUORUM_PCT");
+    await expect(Escrow.deploy(registryAddress, 5, 50, 49, 7200))
+      .to.be.revertedWith("Invalid PARTICIPATION_FLOOR_PCT");
+    await expect(Escrow.deploy(registryAddress, 5, 50, 67, 99))
+      .to.be.revertedWith("Invalid CAMPAIGN_TIMEOUT_BLOCKS");
+  });
+
+  it("allows the Canary 01.5 profile to close with 3 score signers in a 5-oracle set", async function () {
+    const [owner, ...oracles] = await ethers.getSigners();
+    const registry = await deployRegistry(CANARY_REGISTRY_ARGS);
+    const escrow = await deployEscrow(registry, CANARY_ESCROW_ARGS);
+    await registry.setPilotEscrow(await escrow.getAddress());
+
+    for (let i = 0; i < 5; i++) {
+      await registry.connect(oracles[i]).registerOracle(`/ip4/127.0.0.1/tcp/50${i}`, {
+        value: ethers.parseEther("0.1")
+      });
+    }
+
+    const uid = ethers.id("canary-01-5-config");
+    const bounty = ethers.parseEther("0.01");
+    await escrow.connect(owner).fundCampaign(uid, "ipfs://canary", ethers.ZeroHash, { value: bounty });
+
+    const scores = [80, 82, 84];
+    const scoreSigs = await signEip712Score(oracles.slice(0, 3), uid, scores, escrow);
+    const reasons = [1, 1];
+    const abstainSigs = await signEip712Abstain(oracles.slice(3, 5), uid, reasons, escrow);
+
+    await expect(escrow.closeCampaign(uid, scores, scoreSigs, reasons, abstainSigs))
+      .to.emit(escrow, "CampaignClosed")
+      .withArgs(uid, owner.address, bounty, 82);
+  });
+});

--- a/test/GovernanceContracts.test.js
+++ b/test/GovernanceContracts.test.js
@@ -394,7 +394,7 @@ describe("Governance contracts", function () {
   describe("VenomRegistry", function () {
     it("tracks slashed stake separately and allows owner treasury withdrawal", async function () {
       const Registry = await ethers.getContractFactory("VenomRegistry");
-      const registry = await Registry.deploy();
+      const registry = await Registry.deploy(ethers.parseEther("1.0"), 5, 25);
       await registry.setPilotEscrow(owner.address);
 
       const stake = ethers.parseEther("1");

--- a/test/PilotEscrow.v1.1.0.test.js
+++ b/test/PilotEscrow.v1.1.0.test.js
@@ -2,16 +2,18 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 describe("PilotEscrow v1.1.0-rc.1 — Quorum & Cancellation", function () {
+    const REGISTRY_ARGS = [ethers.parseEther("1.0"), 5, 25];
+    const ESCROW_ARGS = [5, 50, 67, 7200];
     let registry, escrow, owner, attacker, oracles;
 
     beforeEach(async function () {
         [owner, attacker, ...oracles] = await ethers.getSigners(); // Hardhat provides 20 signers by default
 
         const Registry = await ethers.getContractFactory("VenomRegistry");
-        registry = await Registry.deploy();
+        registry = await Registry.deploy(...REGISTRY_ARGS);
 
         const Escrow = await ethers.getContractFactory("PilotEscrow");
-        escrow = await Escrow.deploy(await registry.getAddress());
+        escrow = await Escrow.deploy(await registry.getAddress(), ...ESCROW_ARGS);
         await registry.setPilotEscrow(await escrow.getAddress());
 
         // Register 10 active oracles for clean percentage math
@@ -104,6 +106,49 @@ describe("PilotEscrow v1.1.0-rc.1 — Quorum & Cancellation", function () {
         expect(campaign.closed).to.be.true;
     });
 
+    it("4b. Happy path accepts unsorted score arrival order and computes the median on-chain", async function () {
+        const uid = ethers.id("Q4B");
+        await escrow.connect(owner).fundCampaign(uid, "ipfs://test", ethers.id("test"), { value: ethers.parseEther("1.0") });
+
+        const scores = [90, 65, 81, 75, 70, 79];
+        const scoreSigs = await signEip712Score(oracles.slice(0, 6), uid, scores, escrow);
+        const reasons = [1];
+        const abstainSigs = await signEip712Abstain(oracles.slice(6, 7), uid, reasons, escrow);
+
+        await expect(escrow.closeCampaign(uid, scores, scoreSigs, reasons, abstainSigs))
+            .to.emit(escrow, "CampaignClosed")
+            .withArgs(uid, owner.address, ethers.parseEther("1.0"), 79);
+        expect((await escrow.campaigns(uid)).closed).to.be.true;
+    });
+
+    it("4c. closeCampaign reports and slashes score outliers beyond MAX_DEVIATION", async function () {
+        const uid = ethers.id("Q4C");
+        await escrow.connect(owner).fundCampaign(uid, "ipfs://test", ethers.id("test"), { value: ethers.parseEther("1.0") });
+
+        const scores = [70, 40, 70, 70, 70, 70];
+        const scoreSigs = await signEip712Score(oracles.slice(0, 6), uid, scores, escrow);
+        const reasons = [1];
+        const abstainSigs = await signEip712Abstain(oracles.slice(6, 7), uid, reasons, escrow);
+        const stakeBefore = (await registry.oracles(oracles[1].address)).stake;
+
+        const closeTx = escrow.closeCampaign(uid, scores, scoreSigs, reasons, abstainSigs);
+
+        await expect(closeTx)
+            .to.emit(escrow, "DeviationReported")
+            .withArgs(uid, oracles[1].address, 40, 70, 30);
+        await expect(closeTx)
+            .to.emit(registry, "OracleSlashed");
+
+        const honestOracleAfter = await registry.oracles(oracles[0].address);
+        const oracleAfter = await registry.oracles(oracles[1].address);
+        const slashAmount = (stakeBefore * 5n) / 100n;
+        expect(honestOracleAfter.active).to.be.true;
+        expect(oracleAfter.stake).to.equal(stakeBefore - slashAmount);
+        expect(oracleAfter.active).to.be.false;
+        expect(await registry.slashedStakeReserve()).to.equal(slashAmount);
+        expect(await registry.everSlashed(oracles[1].address)).to.be.true;
+    });
+
     it("5. Score-and-abstain by same oracle: abstain is dropped, score counts", async function () {
         const uid = ethers.id("Q5");
         await escrow.connect(owner).fundCampaign(uid, "ipfs://test", ethers.id("test"), { value: ethers.parseEther("1.0") });
@@ -177,7 +222,7 @@ describe("PilotEscrow v1.1.0-rc.1 — Quorum & Cancellation", function () {
 
     it("9. EIP-712 abstain replay across deployments fails", async function () {
         const Escrow = await ethers.getContractFactory("PilotEscrow");
-        const escrowB = await Escrow.deploy(await registry.getAddress());
+        const escrowB = await Escrow.deploy(await registry.getAddress(), ...ESCROW_ARGS);
 
         const uid = ethers.id("R1");
         await escrowB.connect(owner).fundCampaign(uid, "ipfs://test", ethers.id("test"), { value: ethers.parseEther("1.0") });

--- a/test/critical-fixes.test.js
+++ b/test/critical-fixes.test.js
@@ -9,16 +9,18 @@ const {
 const { isPrivateOrWildcardMultiaddr } = require("../src/utils/multiaddr");
 
 describe("VenomRegistry — Unstake, Slash, and Timelock", function () {
+    const REGISTRY_ARGS = [ethers.parseEther("1.0"), 5, 25];
+    const ESCROW_ARGS = [5, 50, 67, 7200];
     let registry, escrow, owner, oracle1, oracle2, attacker;
 
     beforeEach(async function () {
         [owner, oracle1, oracle2, attacker] = await ethers.getSigners();
 
         const Registry = await ethers.getContractFactory("VenomRegistry");
-        registry = await Registry.deploy();
+        registry = await Registry.deploy(...REGISTRY_ARGS);
 
         const Escrow = await ethers.getContractFactory("PilotEscrow");
-        escrow = await Escrow.deploy(await registry.getAddress());
+        escrow = await Escrow.deploy(await registry.getAddress(), ...ESCROW_ARGS);
         await registry.setPilotEscrow(await escrow.getAddress());
     });
 
@@ -133,10 +135,10 @@ describe("VenomRegistry — Unstake, Slash, and Timelock", function () {
     describe("PilotEscrow Timelock Upgrade", function () {
         it("sets PilotEscrow immediately on first call", async function () {
             const Registry2 = await ethers.getContractFactory("VenomRegistry");
-            const registry2 = await Registry2.deploy();
+            const registry2 = await Registry2.deploy(...REGISTRY_ARGS);
 
             const Escrow2 = await ethers.getContractFactory("PilotEscrow");
-            const escrow2 = await Escrow2.deploy(await registry2.getAddress());
+            const escrow2 = await Escrow2.deploy(await registry2.getAddress(), ...ESCROW_ARGS);
 
             expect(await registry2.pilotEscrow()).to.equal(ethers.ZeroAddress);
 
@@ -146,7 +148,7 @@ describe("VenomRegistry — Unstake, Slash, and Timelock", function () {
 
         it("schedules upgrade with 48h timelock on subsequent calls", async function () {
             const Escrow2 = await ethers.getContractFactory("PilotEscrow");
-            const escrow2 = await Escrow2.deploy(await registry.getAddress());
+            const escrow2 = await Escrow2.deploy(await registry.getAddress(), ...ESCROW_ARGS);
 
             const tx = await registry.setPilotEscrow(await escrow2.getAddress());
             const rcpt = await tx.wait();
@@ -162,7 +164,7 @@ describe("VenomRegistry — Unstake, Slash, and Timelock", function () {
 
         it("rejects executePilotEscrowUpgrade before timelock", async function () {
             const Escrow2 = await ethers.getContractFactory("PilotEscrow");
-            const escrow2 = await Escrow2.deploy(await registry.getAddress());
+            const escrow2 = await Escrow2.deploy(await registry.getAddress(), ...ESCROW_ARGS);
 
             await registry.setPilotEscrow(await escrow2.getAddress());
 
@@ -172,7 +174,7 @@ describe("VenomRegistry — Unstake, Slash, and Timelock", function () {
 
         it("executes PilotEscrow upgrade after 48h timelock", async function () {
             const Escrow2 = await ethers.getContractFactory("PilotEscrow");
-            const escrow2 = await Escrow2.deploy(await registry.getAddress());
+            const escrow2 = await Escrow2.deploy(await registry.getAddress(), ...ESCROW_ARGS);
 
             await registry.setPilotEscrow(await escrow2.getAddress());
 


### PR DESCRIPTION
## [Canary 01.5] Module A: Configurable contract constants

This is PR 1 of 8 in the Canary 01.5 integration series.

**Scope.** Parameterizes the protocol constants in `PilotEscrow` and `VenomRegistry`
constructors with explicit bounds checks, and adds three named deploy profiles
(`production`, `canary-01-5`, `solo`) selectable at deploy time via `DEPLOY_PROFILE`.
Same source code now deploys with production-grade constants in production and
relaxed canary constants in canary deployments — no source forks required.

**Constants now configurable** (formerly `constant`, now `immutable` set in constructor):

| Contract | Constant | Production | Canary 01.5 | Solo |
|---|---|---|---|---|
| `VenomRegistry` | `MIN_STAKE` | 1.0 ETH | 0.1 ETH | 0.05 ETH |
| `VenomRegistry` | `SLASH_PERCENT` | 5 | 5 | 5 |
| `VenomRegistry` | `MAX_DEVIATION` | 25 | 25 | 25 |
| `PilotEscrow` | `REQUIRED_ORACLES` | 5 | 3 | 1 |
| `PilotEscrow` | `SCORE_QUORUM_PCT` | 50 | 50 | 50 |
| `PilotEscrow` | `PARTICIPATION_FLOOR_PCT` | 67 | 67 | 67 |
| `PilotEscrow` | `CAMPAIGN_TIMEOUT_BLOCKS` | 7200 | 3600 | 1800 |

Constants kept truly `constant` (protocol-defining): `MAX_SCORES`, `PASS_THRESHOLD`,
`MAX_SCORE`, `CANCEL_FEE_BPS`, `WITHDRAWAL_TIMELOCK`, EIP-712 domain strings.

**Bounds enforced** in the constructors:
- `MIN_STAKE >= 0.01 ether`
- `SLASH_PERCENT ∈ [1, 50]`
- `MAX_DEVIATION ∈ [1, 100]`
- `REQUIRED_ORACLES ∈ [1, MAX_SCORES]`
- `SCORE_QUORUM_PCT ∈ [1, 100]`
- `PARTICIPATION_FLOOR_PCT ∈ [SCORE_QUORUM_PCT, 100]` *(invariant: floor cannot be lower than quorum)*
- `CAMPAIGN_TIMEOUT_BLOCKS ∈ [100, 50000]`

**Tests.** 6 new tests in `test/ConfigurableConstants.test.js`:
- Production profile values flow through public getters
- Registry constructor rejects out-of-bounds values (3 reverts)
- Escrow constructor rejects out-of-bounds values (4 reverts)
- Live close: canary-01-5 profile closes a campaign with 3 scores + 2 abstains in a 5-oracle set

The live close test exercises the exact scenario Canary 01.5's runtime path could
not validate due to mesh-discovery issues. The contract-level path is now
regression-proof.

**Out of scope (handled in subsequent PRs):**
- `aggregator/p2p.js` quorum-constant fail-closed reads → PR 7
- `test/deploy_phase4.test.js` regression coverage of the deploy script → PR 5b
- Module C (operator env generator) which consumes `DEPLOY_PROFILE` → PR 3
- Module D (canary-readiness preflight) which asserts profile match on chain → PR 4

**Test counts:** main baseline 72 passing → PR 1 branch 78 passing (+6).

**Verification:**
- `npm install`: passed
- `npm run compile`: 21 Solidity files, no warnings
- `npm test`: 78 passing
- `node scripts/check-js.js`: 71 JS files, clean

Refs Canary 01.5 (run window 2026-05-08).