### PR TITLE
[Canary 01.5] Module D canary-readiness preflight

### DIFF
--- a/scripts/pilot/cist/__tests__/canary-readiness.test.js
+++ b/scripts/pilot/cist/__tests__/canary-readiness.test.js
@@ -1,0 +1,277 @@
+'use strict';
+
+const { expect } = require('chai');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { ethers } = require('ethers');
+
+const { STATE, validatePhaseResult } = require('../phases');
+const {
+  PHASE_INDEX,
+  parseOperatorEnvFlags,
+  resolveBalanceFloor,
+  runCanaryReadiness,
+} = require('../phases/canary-readiness');
+
+const REGISTRY = '0x1000000000000000000000000000000000000001';
+const ESCROW = '0x2000000000000000000000000000000000000002';
+const OP1 = '0x3000000000000000000000000000000000000003';
+const OP2 = '0x4000000000000000000000000000000000000004';
+
+function makeContext(overrides = {}) {
+  return {
+    runId: 'cist-20260427-143012-a83f9c1e',
+    runDir: '/tmp/test-run',
+    mode: 'live-testnet',
+    ...overrides,
+  };
+}
+
+function makeManifest(overrides = {}) {
+  return {
+    schemaVersion: 1,
+    profile: 'canary-01-5',
+    deployment: {
+      network: 'base-sepolia',
+      chainId: 84532,
+      registry: REGISTRY,
+      escrow: ESCROW,
+    },
+    operators: [
+      { id: 'op1', address: OP1, envPath: 'operator-1/.env', healthPort: 3000, queueSuffix: 'op1' },
+      { id: 'op2', address: OP2, envPath: 'operator-2/.env', healthPort: 3001, queueSuffix: 'op2' },
+    ],
+    generatedAt: '2026-05-08T09:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function writeCanaryTree(root, manifest = makeManifest(), envOverrides = {}) {
+  fs.writeFileSync(path.join(root, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+  for (const operator of manifest.operators || []) {
+    const envPath = path.join(root, operator.envPath);
+    fs.mkdirSync(path.dirname(envPath), { recursive: true });
+    const privateKey = envOverrides.privateKey || `0x${operator.id === 'op1' ? '1' : '2'.padStart(64, '2')}`;
+    const privateMultiaddr = envOverrides.privateMultiaddr === true ? 'true' : 'false';
+    fs.writeFileSync(envPath, [
+      `OPERATOR_PRIVATE_KEY=${privateKey}`,
+      `OPERATOR_QUEUE_SUFFIX=${operator.queueSuffix}`,
+      `VENOM_ALLOW_PRIVATE_MULTIADDR=${privateMultiaddr}`,
+      '',
+    ].join('\n'));
+  }
+}
+
+function makeContracts(overrides = {}) {
+  return {
+    escrow: {
+      REQUIRED_ORACLES: async () => overrides.REQUIRED_ORACLES ?? 3n,
+      SCORE_QUORUM_PCT: async () => overrides.SCORE_QUORUM_PCT ?? 50n,
+      PARTICIPATION_FLOOR_PCT: async () => overrides.PARTICIPATION_FLOOR_PCT ?? 67n,
+      CAMPAIGN_TIMEOUT_BLOCKS: async () => overrides.CAMPAIGN_TIMEOUT_BLOCKS ?? 3600n,
+    },
+    registry: {
+      MIN_STAKE: async () => overrides.MIN_STAKE ?? ethers.parseEther('0.1'),
+      SLASH_PERCENT: async () => overrides.SLASH_PERCENT ?? 5n,
+      MAX_DEVIATION: async () => overrides.MAX_DEVIATION ?? 25n,
+    },
+  };
+}
+
+function makeProvider(balanceByAddress = {}) {
+  return {
+    getBalance: async (address) => {
+      return balanceByAddress[ethers.getAddress(address)] ?? ethers.parseEther('0.2');
+    },
+  };
+}
+
+async function runPhase(root, options = {}) {
+  const contracts = makeContracts(options.constants || {});
+  return runCanaryReadiness(makeContext(options.context || {}), {
+    canaryEnvsDir: root,
+    env: {
+      VENOM_REGISTRY_ADDRESS: REGISTRY,
+      PILOT_ESCROW_ADDRESS: ESCROW,
+      ...options.env,
+    },
+    provider: options.provider || makeProvider(options.balances || {}),
+    registry: contracts.registry,
+    escrow: contracts.escrow,
+    registryAddress: options.registryAddress || REGISTRY,
+    escrowAddress: options.escrowAddress || ESCROW,
+    localOnly: options.localOnly,
+  });
+}
+
+describe('CIST Phase 9: Canary multi-operator readiness', function () {
+  let root;
+
+  beforeEach(function () {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'cist-canary-'));
+  });
+
+  afterEach(function () {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('declares PHASE_INDEX as 9', function () {
+    expect(PHASE_INDEX).to.equal(9);
+  });
+
+  it('SKIPs when --canary-envs is absent', async function () {
+    const result = await runCanaryReadiness(makeContext(), {});
+    expect(result.state).to.equal(STATE.SKIP);
+    expect(result.codes).to.deep.equal([]);
+    expect(validatePhaseResult(result)).to.equal(true);
+  });
+
+  it('PASSes when manifest, constants, balances, suffixes, and env files are valid', async function () {
+    writeCanaryTree(root);
+    const result = await runPhase(root);
+
+    expect(result.state).to.equal(STATE.PASS);
+    expect(result.codes).to.deep.equal([]);
+    expect(result.manifest).to.deep.include({
+      profile: 'canary-01-5',
+      operatorCount: 2,
+    });
+    expect(validatePhaseResult(result)).to.equal(true);
+  });
+
+  it('FAILs on invalid manifest schema', async function () {
+    writeCanaryTree(root, makeManifest({ schemaVersion: 0 }));
+    const result = await runPhase(root);
+
+    expect(result.state).to.equal(STATE.FAIL);
+    expect(result.codes).to.deep.equal(['CANARY_MANIFEST_INVALID']);
+  });
+
+  it('FAILs when manifest deployment addresses do not match the preflight target', async function () {
+    writeCanaryTree(root);
+    const result = await runPhase(root, {
+      registryAddress: '0x5000000000000000000000000000000000000005',
+    });
+
+    expect(result.state).to.equal(STATE.FAIL);
+    expect(result.codes).to.include('CANARY_DEPLOYMENT_MISMATCH');
+  });
+
+  it('FAILs when deployed constants do not match the canary profile', async function () {
+    writeCanaryTree(root);
+    const result = await runPhase(root, {
+      constants: { REQUIRED_ORACLES: 5n },
+    });
+
+    expect(result.state).to.equal(STATE.FAIL);
+    expect(result.codes).to.include('CANARY_PROFILE_MISMATCH');
+    expect(result.notes.join(' ')).to.include('REQUIRED_ORACLES');
+  });
+
+  it('FAILs when an operator balance is below the floor', async function () {
+    writeCanaryTree(root);
+    const result = await runPhase(root, {
+      balances: { [OP2]: ethers.parseEther('0.15') },
+    });
+
+    expect(result.state).to.equal(STATE.FAIL);
+    expect(result.codes).to.include('CANARY_OPERATOR_BALANCE_LOW');
+    expect(result.notes.join(' ')).to.include('op2');
+  });
+
+  it('WARNs when an operator balance is just above the floor', async function () {
+    writeCanaryTree(root);
+    const result = await runPhase(root, {
+      balances: { [OP2]: ethers.parseEther('0.165') },
+    });
+
+    expect(result.state).to.equal(STATE.WARN);
+    expect(result.codes).to.deep.equal([]);
+  });
+
+  it('FAILs when a generated operator matches the deployer address', async function () {
+    const deployer = ethers.Wallet.createRandom();
+    writeCanaryTree(root, makeManifest({
+      operators: [
+        { id: 'op1', address: deployer.address, envPath: 'operator-1/.env', healthPort: 3000, queueSuffix: 'op1' },
+      ],
+    }));
+
+    const result = await runPhase(root, {
+      env: { DEPLOYER_PRIVATE_KEY: deployer.privateKey },
+    });
+
+    expect(result.state).to.equal(STATE.FAIL);
+    expect(result.codes).to.include('CANARY_OPERATOR_IS_DEPLOYER');
+  });
+
+  it('FAILs on duplicate or invalid queue suffixes', async function () {
+    writeCanaryTree(root, makeManifest({
+      operators: [
+        { id: 'op1', address: OP1, envPath: 'operator-1/.env', healthPort: 3000, queueSuffix: 'op1' },
+        { id: 'op2', address: OP2, envPath: 'operator-2/.env', healthPort: 3001, queueSuffix: 'op1' },
+      ],
+    }));
+
+    const result = await runPhase(root);
+
+    expect(result.state).to.equal(STATE.FAIL);
+    expect(result.codes).to.include('CANARY_QUEUE_SUFFIX_INVALID');
+  });
+
+  it('FAILs when private multiaddr is enabled outside local-only mode', async function () {
+    writeCanaryTree(root, makeManifest(), { privateMultiaddr: true });
+    const result = await runPhase(root);
+
+    expect(result.state).to.equal(STATE.FAIL);
+    expect(result.codes).to.include('CANARY_PRIVATE_MULTIADDR');
+  });
+
+  it('allows private multiaddr when local-only is set', async function () {
+    writeCanaryTree(root, makeManifest(), { privateMultiaddr: true });
+    const result = await runPhase(root, { localOnly: true });
+
+    expect(result.state).to.equal(STATE.PASS);
+    expect(result.codes).to.not.include('CANARY_PRIVATE_MULTIADDR');
+  });
+
+  it('FAILs when an operator env file is unreadable', async function () {
+    writeCanaryTree(root);
+    fs.rmSync(path.join(root, 'operator-2', '.env'));
+    const result = await runPhase(root);
+
+    expect(result.state).to.equal(STATE.FAIL);
+    expect(result.codes).to.include('CANARY_OPERATOR_ENV_UNREADABLE');
+  });
+
+  it('parses only operator env flags needed by the readiness phase', function () {
+    const envPath = path.join(root, '.env');
+    fs.writeFileSync(envPath, [
+      'OPERATOR_PRIVATE_KEY=0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      'OPERATOR_QUEUE_SUFFIX=op1',
+      'VENOM_ALLOW_PRIVATE_MULTIADDR=true',
+    ].join('\n'));
+
+    expect(parseOperatorEnvFlags(envPath)).to.deep.equal({
+      privateMultiaddr: true,
+      queueSuffix: 'op1',
+    });
+  });
+
+  it('does not leak private-key-shaped values into phase output', async function () {
+    writeCanaryTree(root, makeManifest(), {
+      privateKey: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    });
+    const result = await runPhase(root);
+    const serialized = JSON.stringify(result);
+
+    expect(serialized).to.not.match(/0x[0-9a-fA-F]{64}/);
+  });
+
+  it('uses an explicit operator balance floor when configured', function () {
+    expect(resolveBalanceFloor('canary-01-5', ethers.parseEther('0.1'), {
+      PREFLIGHT_OPERATOR_BALANCE_FLOOR: '0.2',
+    })).to.equal(ethers.parseEther('0.2'));
+  });
+});

--- a/scripts/pilot/cist/__tests__/p2p-aggregation.test.js
+++ b/scripts/pilot/cist/__tests__/p2p-aggregation.test.js
@@ -161,6 +161,15 @@ describe('CIST Phase 7: P2P / signature aggregation', function () {
     expect(validatePhaseResult(result)).to.equal(true);
   });
 
+  it('SKIPs legacy single-operator checks when canary envs are active', async function () {
+    const result = await runP2pAggregation(makeContext({ canaryEnvsDir: '/tmp/canary' }), {});
+
+    expect(result.state).to.equal(STATE.SKIP);
+    expect(result.codes).to.deep.equal([]);
+    expect(result.notes[0]).to.include('deferring legacy single-operator P2P checks to Phase 9');
+    expect(validatePhaseResult(result)).to.equal(true);
+  });
+
   it('FAILs with P2P_ORACLE_FACTORY_INVALID when the oracle factory is malformed', async function () {
     const result = await runP2pAggregation(makeContext(), {
       chainId: HARDHAT_CHAIN_ID,

--- a/scripts/pilot/cist/__tests__/phases.test.js
+++ b/scripts/pilot/cist/__tests__/phases.test.js
@@ -12,7 +12,7 @@ const {
 } = require('../phases');
 
 describe('CIST phases', function () {
-  it('locks down the 8-phase order', function () {
+  it('locks down the phase order', function () {
     expect(PHASES.map((phase) => phase.name)).to.deep.equal([
       'Config and redaction preflight',
       'Chain and contract binding',
@@ -21,6 +21,7 @@ describe('CIST phases', function () {
       'Payload resolution',
       'Worker decision',
       'P2P / signature aggregation',
+      'Canary multi-operator readiness',
       'Report and teardown integrity'
     ]);
   });
@@ -28,6 +29,7 @@ describe('CIST phases', function () {
   it('indexes phases by index and key', function () {
     expect(PHASE_BY_INDEX[1].key).to.equal('config');
     expect(PHASE_BY_KEY.report.index).to.equal(8);
+    expect(PHASE_BY_KEY.canary.index).to.equal(9);
   });
 
   it('validates known states', function () {

--- a/scripts/pilot/cist/__tests__/preflight.test.js
+++ b/scripts/pilot/cist/__tests__/preflight.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const { expect } = require('chai');
+const fs = require('node:fs');
+const path = require('node:path');
 const { ethers } = require('ethers');
 
 const { STATE } = require('../phases');
@@ -14,6 +16,8 @@ const {
   runP2pDialbackCheck,
   runLivePreflightGates,
   applyLivePreflightGates,
+  buildPreflightQueueName,
+  isBlockingPreflightPhase,
 } = require('../../preflight');
 
 function arrayBufferFromText(text) {
@@ -38,12 +42,16 @@ describe('pilot live preflight', function () {
       '--skip-p2p-dialback',
       '--ipfs-cid=bafkreitest',
       '--ipfs-sha256=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      '--canary-envs=.venom-canary',
+      '--local-only',
     ]);
 
     expect(options).to.deep.include({
       network: 'base-sepolia',
       json: true,
       skipP2pDialback: true,
+      localOnly: true,
+      canaryEnvsDir: '.venom-canary',
       ipfsCid: 'bafkreitest',
       ipfsSha256: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
     });
@@ -61,6 +69,48 @@ describe('pilot live preflight', function () {
 
   it('renders discoverable help for the package command', function () {
     expect(renderHelp()).to.include('npm run pilot:preflight -- --network=base-sepolia');
+    expect(renderHelp()).to.include('--canary-envs=<dir>');
+  });
+
+  it('keeps the registry oracle ABI aligned with the deployed tuple shape', function () {
+    // Regression: MAIN-FIX-2
+    const text = fs.readFileSync(path.resolve(__dirname, '../../preflight.js'), 'utf8');
+
+    expect(text).to.include(
+      'function oracles(address) view returns (address operator, uint256 stake, uint256 scoreCount, uint256 lastActive, bool active, string multiaddr)'
+    );
+  });
+
+  it('builds the live preflight queue name with the operator suffix', function () {
+    // Regression: MF-8
+    expect(buildPreflightQueueName({
+      QUEUE_NAME: 'venom-campaigns',
+      OPERATOR_QUEUE_SUFFIX: 'op2',
+    })).to.equal('venom-campaigns-op2');
+    expect(buildPreflightQueueName({
+      QUEUE_NAME: 'venom-campaigns',
+      OPERATOR_QUEUE_SUFFIX: '',
+    })).to.equal('venom-campaigns');
+    expect(() => buildPreflightQueueName({
+      QUEUE_NAME: 'venom-campaigns',
+      OPERATOR_QUEUE_SUFFIX: 'op:2',
+    })).to.throw('OPERATOR_QUEUE_SUFFIX');
+  });
+
+  it('does not treat the intentional canary Phase 7 SKIP as blocking Phase 9', function () {
+    // Regression: MF-5
+    expect(isBlockingPreflightPhase({
+      index: 7,
+      state: STATE.SKIP,
+    }, { canaryEnvsDir: '.venom-canary' })).to.equal(false);
+    expect(isBlockingPreflightPhase({
+      index: 7,
+      state: STATE.SKIP,
+    }, {})).to.equal(true);
+    expect(isBlockingPreflightPhase({
+      index: 9,
+      state: STATE.SKIP,
+    }, { canaryEnvsDir: '.venom-canary' })).to.equal(true);
   });
 
   it('derives the ML health URL from the evaluate URL', function () {

--- a/scripts/pilot/cist/codes.js
+++ b/scripts/pilot/cist/codes.js
@@ -13,7 +13,8 @@ const PHASE = Object.freeze({
   PAYLOAD: 5,
   WORKER: 6,
   P2P: 7,
-  REPORT: 8
+  REPORT: 8,
+  CANARY: 9
 });
 
 const CODES = Object.freeze({
@@ -262,6 +263,54 @@ const CODES = Object.freeze({
     summary: 'Live preflight gate evaluation failed unexpectedly.',
     severity: SEVERITY.FAIL,
     phase: PHASE.P2P
+  },
+  CANARY_MANIFEST_INVALID: {
+    code: 'CANARY_MANIFEST_INVALID',
+    summary: 'Canary operator manifest is missing, unreadable, or malformed.',
+    severity: SEVERITY.FAIL,
+    phase: PHASE.CANARY
+  },
+  CANARY_DEPLOYMENT_MISMATCH: {
+    code: 'CANARY_DEPLOYMENT_MISMATCH',
+    summary: 'Canary manifest deployment addresses do not match the preflight target.',
+    severity: SEVERITY.FAIL,
+    phase: PHASE.CANARY
+  },
+  CANARY_PROFILE_MISMATCH: {
+    code: 'CANARY_PROFILE_MISMATCH',
+    summary: 'Live contract constants do not match the canary profile manifest.',
+    severity: SEVERITY.FAIL,
+    phase: PHASE.CANARY
+  },
+  CANARY_OPERATOR_BALANCE_LOW: {
+    code: 'CANARY_OPERATOR_BALANCE_LOW',
+    summary: 'One or more canary operator wallets are below the configured balance floor.',
+    severity: SEVERITY.FAIL,
+    phase: PHASE.CANARY
+  },
+  CANARY_OPERATOR_IS_DEPLOYER: {
+    code: 'CANARY_OPERATOR_IS_DEPLOYER',
+    summary: 'A generated canary operator address matches the deployer address.',
+    severity: SEVERITY.FAIL,
+    phase: PHASE.CANARY
+  },
+  CANARY_QUEUE_SUFFIX_INVALID: {
+    code: 'CANARY_QUEUE_SUFFIX_INVALID',
+    summary: 'Canary operator queue suffixes are missing, invalid, or duplicated.',
+    severity: SEVERITY.FAIL,
+    phase: PHASE.CANARY
+  },
+  CANARY_PRIVATE_MULTIADDR: {
+    code: 'CANARY_PRIVATE_MULTIADDR',
+    summary: 'A canary operator env enables private multiaddr registration outside local-only mode.',
+    severity: SEVERITY.FAIL,
+    phase: PHASE.CANARY
+  },
+  CANARY_OPERATOR_ENV_UNREADABLE: {
+    code: 'CANARY_OPERATOR_ENV_UNREADABLE',
+    summary: 'A canary operator env file could not be read.',
+    severity: SEVERITY.FAIL,
+    phase: PHASE.CANARY
   },
   REPORT_WRITE_FAILED: {
     code: 'REPORT_WRITE_FAILED',

--- a/scripts/pilot/cist/phases.js
+++ b/scripts/pilot/cist/phases.js
@@ -15,6 +15,7 @@ const PHASES = Object.freeze([
   { index: 5, key: 'payload', name: 'Payload resolution' },
   { index: 6, key: 'worker', name: 'Worker decision' },
   { index: 7, key: 'p2p', name: 'P2P / signature aggregation' },
+  { index: 9, key: 'canary', name: 'Canary multi-operator readiness' },
   { index: 8, key: 'report', name: 'Report and teardown integrity' }
 ]);
 

--- a/scripts/pilot/cist/phases/canary-readiness.js
+++ b/scripts/pilot/cist/phases/canary-readiness.js
@@ -1,0 +1,355 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { performance } = require('node:perf_hooks');
+const { ethers } = require('ethers');
+
+const { STATE, createPhaseResult } = require('../phases');
+
+const PHASE_INDEX = 9;
+const DEFAULT_CANARY_BALANCE_FLOOR_ETH = '0.16';
+const PRIVATE_KEY_PATTERN = /0x[0-9a-fA-F]{64}/;
+const QUEUE_SUFFIX_PATTERN = /^[a-zA-Z0-9._-]{1,64}$/;
+
+const PROFILE_CONSTANTS = Object.freeze({
+  'canary-01-5': Object.freeze({
+    REQUIRED_ORACLES: 3,
+    SCORE_QUORUM_PCT: 50,
+    PARTICIPATION_FLOOR_PCT: 67,
+    CAMPAIGN_TIMEOUT_BLOCKS: 3600,
+    MIN_STAKE: '100000000000000000',
+    SLASH_PERCENT: 5,
+    MAX_DEVIATION: 25,
+  }),
+});
+
+const ESCROW_CONSTANTS = Object.freeze([
+  'REQUIRED_ORACLES',
+  'SCORE_QUORUM_PCT',
+  'PARTICIPATION_FLOOR_PCT',
+  'CAMPAIGN_TIMEOUT_BLOCKS',
+]);
+
+const REGISTRY_CONSTANTS = Object.freeze([
+  'MIN_STAKE',
+  'SLASH_PERCENT',
+  'MAX_DEVIATION',
+]);
+
+function addCode(codes, code) {
+  if (!codes.includes(code)) codes.push(code);
+}
+
+function normalizeAddress(value, label) {
+  try {
+    return ethers.getAddress(value);
+  } catch {
+    throw new Error(`${label} must be a valid EVM address`);
+  }
+}
+
+function normalizeQueueSuffix(input) {
+  const suffix = String(input || '').trim();
+  if (!suffix || !QUEUE_SUFFIX_PATTERN.test(suffix)) {
+    throw new Error('queue suffix must be 1-64 characters using only letters, numbers, dot, underscore, or dash');
+  }
+  return suffix;
+}
+
+function readManifest(manifestPath, fsImpl = fs) {
+  try {
+    return JSON.parse(fsImpl.readFileSync(manifestPath, 'utf8'));
+  } catch (error) {
+    throw new Error(`Could not read manifest.json: ${error.message}`);
+  }
+}
+
+function validateManifestShape(manifest) {
+  if (!manifest || typeof manifest !== 'object') {
+    throw new Error('manifest.json must contain a JSON object');
+  }
+  if (manifest.schemaVersion !== 1) {
+    throw new Error('manifest.schemaVersion must equal 1');
+  }
+  if (!PROFILE_CONSTANTS[manifest.profile]) {
+    throw new Error(`Unsupported canary profile: ${manifest.profile}`);
+  }
+  if (!manifest.deployment || typeof manifest.deployment !== 'object') {
+    throw new Error('manifest.deployment is required');
+  }
+  normalizeAddress(manifest.deployment.registry, 'manifest.deployment.registry');
+  normalizeAddress(manifest.deployment.escrow, 'manifest.deployment.escrow');
+  if (!Number.isSafeInteger(Number(manifest.deployment.chainId))) {
+    throw new Error('manifest.deployment.chainId is required');
+  }
+  if (!Array.isArray(manifest.operators) || manifest.operators.length === 0) {
+    throw new Error('manifest.operators must be a non-empty array');
+  }
+
+  for (const [index, operator] of manifest.operators.entries()) {
+    if (!operator || typeof operator !== 'object') {
+      throw new Error(`manifest.operators[${index}] must be an object`);
+    }
+    if (typeof operator.id !== 'string' || !operator.id) {
+      throw new Error(`manifest.operators[${index}].id is required`);
+    }
+    normalizeAddress(operator.address, `manifest.operators[${index}].address`);
+    if (typeof operator.envPath !== 'string' || !operator.envPath) {
+      throw new Error(`manifest.operators[${index}].envPath is required`);
+    }
+    if (typeof operator.queueSuffix !== 'string' || !operator.queueSuffix) {
+      throw new Error(`manifest.operators[${index}].queueSuffix is required`);
+    }
+  }
+}
+
+function parseOperatorEnvFlags(envPath, fsImpl = fs) {
+  let text;
+  try {
+    text = fsImpl.readFileSync(envPath, 'utf8');
+  } catch (error) {
+    const wrapped = new Error(`Could not read operator env ${envPath}: ${error.message}`);
+    wrapped.code = 'CANARY_OPERATOR_ENV_UNREADABLE';
+    throw wrapped;
+  }
+
+  const flags = {
+    privateMultiaddr: false,
+    queueSuffix: null,
+  };
+
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq < 0) continue;
+    const key = line.slice(0, eq).trim();
+    if (key === 'VENOM_ALLOW_PRIVATE_MULTIADDR') {
+      flags.privateMultiaddr = line.slice(eq + 1).trim().toLowerCase() === 'true';
+    } else if (key === 'OPERATOR_QUEUE_SUFFIX') {
+      flags.queueSuffix = line.slice(eq + 1).trim();
+    }
+  }
+
+  return flags;
+}
+
+async function readContractConstants(escrow, registry) {
+  const constants = {};
+  for (const key of ESCROW_CONSTANTS) {
+    if (!escrow || typeof escrow[key] !== 'function') {
+      throw new Error(`Escrow contract missing ${key}()`);
+    }
+    constants[key] = await escrow[key]();
+  }
+  for (const key of REGISTRY_CONSTANTS) {
+    if (!registry || typeof registry[key] !== 'function') {
+      throw new Error(`Registry contract missing ${key}()`);
+    }
+    constants[key] = await registry[key]();
+  }
+  return constants;
+}
+
+function expectedProfileConstants(profile) {
+  const constants = PROFILE_CONSTANTS[profile];
+  if (!constants) throw new Error(`Unsupported canary profile: ${profile}`);
+  return constants;
+}
+
+function compareConstants(actual, expected, notes) {
+  let ok = true;
+  for (const [key, expectedValue] of Object.entries(expected)) {
+    if (String(actual[key]) !== String(expectedValue)) {
+      notes.push(`${key} mismatch: expected ${expectedValue}, got ${actual[key]}`);
+      ok = false;
+    }
+  }
+  return ok;
+}
+
+function resolveBalanceFloor(profile, minStake, env = {}) {
+  if (env.PREFLIGHT_OPERATOR_BALANCE_FLOOR) {
+    return ethers.parseEther(env.PREFLIGHT_OPERATOR_BALANCE_FLOOR);
+  }
+  if (profile === 'canary-01-5' && !env.PREFLIGHT_BALANCE_BUFFER_ETH) {
+    return ethers.parseEther(DEFAULT_CANARY_BALANCE_FLOOR_ETH);
+  }
+  return minStake + ethers.parseEther(env.PREFLIGHT_BALANCE_BUFFER_ETH || '0.02');
+}
+
+function redactSecrets(value) {
+  const text = typeof value === 'string' ? value : JSON.stringify(value);
+  return !PRIVATE_KEY_PATTERN.test(text);
+}
+
+async function runCanaryReadiness(context, options = {}) {
+  const start = performance.now();
+  const codes = [];
+  const notes = [];
+  const env = options.env || process.env;
+  const canaryEnvsDir = options.canaryEnvsDir || context.canaryEnvsDir || null;
+  const localOnly = options.localOnly === true || context.localOnly === true;
+
+  if (!canaryEnvsDir) {
+    return createPhaseResult(PHASE_INDEX, STATE.SKIP, {
+      durationMs: Math.round(performance.now() - start),
+      notes: ['--canary-envs not supplied; canary readiness gates skipped.'],
+    });
+  }
+
+  let manifest;
+  const manifestPath = path.resolve(canaryEnvsDir, 'manifest.json');
+
+  try {
+    manifest = readManifest(manifestPath, options.fs || fs);
+    validateManifestShape(manifest);
+  } catch (error) {
+    addCode(codes, 'CANARY_MANIFEST_INVALID');
+    notes.push(error.message);
+    return createPhaseResult(PHASE_INDEX, STATE.FAIL, {
+      durationMs: Math.round(performance.now() - start),
+      codes,
+      notes,
+    });
+  }
+
+  const manifestSummary = {
+    profile: manifest.profile,
+    operatorCount: manifest.operators.length,
+    manifestPath,
+  };
+
+  const targetRegistry = options.registryAddress || env.VENOM_REGISTRY_ADDRESS;
+  const targetEscrow = options.escrowAddress || env.PILOT_ESCROW_ADDRESS;
+
+  try {
+    if (normalizeAddress(manifest.deployment.registry, 'manifest registry') !== normalizeAddress(targetRegistry, 'VENOM_REGISTRY_ADDRESS')) {
+      addCode(codes, 'CANARY_DEPLOYMENT_MISMATCH');
+      notes.push('Manifest registry address does not match VENOM_REGISTRY_ADDRESS.');
+    }
+    if (normalizeAddress(manifest.deployment.escrow, 'manifest escrow') !== normalizeAddress(targetEscrow, 'PILOT_ESCROW_ADDRESS')) {
+      addCode(codes, 'CANARY_DEPLOYMENT_MISMATCH');
+      notes.push('Manifest escrow address does not match PILOT_ESCROW_ADDRESS.');
+    }
+  } catch (error) {
+    addCode(codes, 'CANARY_DEPLOYMENT_MISMATCH');
+    notes.push(error.message);
+  }
+
+  let minStake = 0n;
+  try {
+    const actualConstants = await readContractConstants(options.escrow, options.registry);
+    minStake = BigInt(actualConstants.MIN_STAKE);
+    if (!compareConstants(actualConstants, expectedProfileConstants(manifest.profile), notes)) {
+      addCode(codes, 'CANARY_PROFILE_MISMATCH');
+    }
+  } catch (error) {
+    addCode(codes, 'CANARY_PROFILE_MISMATCH');
+    notes.push(`Could not verify deployed profile constants: ${error.message}`);
+  }
+
+  const suffixes = new Set();
+  for (const operator of manifest.operators) {
+    try {
+      const normalizedSuffix = normalizeQueueSuffix(operator.queueSuffix);
+      if (suffixes.has(normalizedSuffix)) {
+        addCode(codes, 'CANARY_QUEUE_SUFFIX_INVALID');
+        notes.push(`${operator.id} duplicates queue suffix ${normalizedSuffix}.`);
+      }
+      suffixes.add(normalizedSuffix);
+    } catch (error) {
+      addCode(codes, 'CANARY_QUEUE_SUFFIX_INVALID');
+      notes.push(`${operator.id} has invalid queue suffix: ${error.message}`);
+    }
+  }
+
+  if (env.DEPLOYER_PRIVATE_KEY) {
+    try {
+      const deployerAddress = normalizeAddress(new ethers.Wallet(env.DEPLOYER_PRIVATE_KEY).address, 'deployer address');
+      for (const operator of manifest.operators) {
+        if (normalizeAddress(operator.address, `${operator.id} address`) === deployerAddress) {
+          addCode(codes, 'CANARY_OPERATOR_IS_DEPLOYER');
+          notes.push(`${operator.id} address matches DEPLOYER_PRIVATE_KEY address.`);
+        }
+      }
+    } catch (error) {
+      addCode(codes, 'CANARY_OPERATOR_IS_DEPLOYER');
+      notes.push(`Could not derive DEPLOYER_PRIVATE_KEY address: ${error.message}`);
+    }
+  }
+
+  if (options.provider && minStake > 0n) {
+    let anyWarnBalance = false;
+    const balanceFloor = resolveBalanceFloor(manifest.profile, minStake, env);
+    const warnFloor = (balanceFloor * 110n) / 100n;
+    for (const operator of manifest.operators) {
+      try {
+        const balance = await options.provider.getBalance(operator.address);
+        if (balance < balanceFloor) {
+          addCode(codes, 'CANARY_OPERATOR_BALANCE_LOW');
+          notes.push(`${operator.id} balance ${ethers.formatEther(balance)} ETH below floor ${ethers.formatEther(balanceFloor)} ETH.`);
+        } else if (balance < warnFloor) {
+          anyWarnBalance = true;
+          notes.push(`${operator.id} balance ${ethers.formatEther(balance)} ETH is within 10% of the floor ${ethers.formatEther(balanceFloor)} ETH.`);
+        }
+      } catch (error) {
+        addCode(codes, 'CANARY_OPERATOR_BALANCE_LOW');
+        notes.push(`Could not read balance for ${operator.id}: ${error.message}`);
+      }
+    }
+    if (anyWarnBalance && !codes.includes('CANARY_OPERATOR_BALANCE_LOW')) {
+      notes.push('One or more operator balances are close to the configured floor.');
+    }
+  }
+
+  for (const operator of manifest.operators) {
+    const envPath = path.resolve(canaryEnvsDir, operator.envPath);
+    try {
+      const flags = parseOperatorEnvFlags(envPath, options.fs || fs);
+      if (flags.queueSuffix && flags.queueSuffix !== operator.queueSuffix) {
+        addCode(codes, 'CANARY_QUEUE_SUFFIX_INVALID');
+        notes.push(`${operator.id} env queue suffix ${flags.queueSuffix} does not match manifest ${operator.queueSuffix}.`);
+      }
+      if (!localOnly && flags.privateMultiaddr) {
+        addCode(codes, 'CANARY_PRIVATE_MULTIADDR');
+        notes.push(`${operator.id} enables VENOM_ALLOW_PRIVATE_MULTIADDR outside --local-only.`);
+      }
+    } catch (error) {
+      addCode(codes, error.code === 'CANARY_OPERATOR_ENV_UNREADABLE' ? error.code : 'CANARY_OPERATOR_ENV_UNREADABLE');
+      notes.push(error.message);
+    }
+  }
+
+  const state = codes.length > 0
+    ? STATE.FAIL
+    : notes.some((note) => note.includes('within 10%') || note.includes('close to the configured floor'))
+      ? STATE.WARN
+      : STATE.PASS;
+
+  const result = createPhaseResult(PHASE_INDEX, state, {
+    durationMs: Math.round(performance.now() - start),
+    codes,
+    notes,
+    manifest: manifestSummary,
+  });
+
+  if (!redactSecrets(result)) {
+    return createPhaseResult(PHASE_INDEX, STATE.FAIL, {
+      durationMs: Math.round(performance.now() - start),
+      codes: ['CANARY_MANIFEST_INVALID'],
+      notes: ['Canary readiness result contained secret-shaped material and was suppressed.'],
+    });
+  }
+
+  return result;
+}
+
+module.exports = {
+  PHASE_INDEX,
+  parseOperatorEnvFlags,
+  resolveBalanceFloor,
+  validateManifestShape,
+  runCanaryReadiness,
+};

--- a/scripts/pilot/cist/phases/p2p-aggregation.js
+++ b/scripts/pilot/cist/phases/p2p-aggregation.js
@@ -86,8 +86,20 @@ async function runP2pAggregation(context, options = {}) {
   const notes = [];
   const p2p = { configured: false };
   const signatures = [];
+  const canaryEnvsDir = context.canaryEnvsDir || options.canaryEnvsDir || null;
 
   try {
+    if (canaryEnvsDir) {
+      notes.push('Canary multi-operator mode active; deferring legacy single-operator P2P checks to Phase 9 (canary-readiness).');
+      return createPhaseResult(PHASE_INDEX, STATE.SKIP, {
+        durationMs: Math.max(0, Math.round(performance.now() - started)),
+        codes,
+        notes,
+        p2p,
+        signatures,
+      });
+    }
+
     if (options.chainId === undefined || options.chainId === null) {
       codes.push('P2P_CHAIN_ID_MISSING');
       notes.push('Chain ID is required for P2P aggregation');

--- a/scripts/pilot/preflight.js
+++ b/scripts/pilot/preflight.js
@@ -18,6 +18,7 @@ const { buildRunContext, makeConfigError } = require('./cist/config');
 const { STATE } = require('./cist/phases');
 const { writeReports } = require('./cist/report');
 const { updateLatestPointer } = require('./cist/latest');
+const { runCanaryReadiness } = require('./cist/phases/canary-readiness');
 
 const SUPPORTED_NETWORKS = Object.freeze({
   'base-sepolia': {
@@ -29,11 +30,16 @@ const SUPPORTED_NETWORKS = Object.freeze({
 const REGISTRY_ABI = Object.freeze([
   'function activeOracleCount() view returns (uint256)',
   'function MIN_STAKE() view returns (uint256)',
+  'function SLASH_PERCENT() view returns (uint256)',
+  'function MAX_DEVIATION() view returns (uint256)',
   'function oracles(address) view returns (address operator, uint256 stake, uint256 scoreCount, uint256 lastActive, bool active, string multiaddr)',
 ]);
 
 const ESCROW_ABI = Object.freeze([
   'function REQUIRED_ORACLES() view returns (uint256)',
+  'function SCORE_QUORUM_PCT() view returns (uint256)',
+  'function PARTICIPATION_FLOOR_PCT() view returns (uint256)',
+  'function CAMPAIGN_TIMEOUT_BLOCKS() view returns (uint256)',
 ]);
 
 const PREFLIGHT_DID_NOT_VERIFY = Object.freeze([
@@ -54,6 +60,8 @@ function parsePreflightArgs(argv = []) {
     ipfsSha256: null,
     skipP2pDialback: false,
     requireP2pDialback: false,
+    canaryEnvsDir: null,
+    localOnly: false,
   };
 
   for (const arg of argv) {
@@ -63,6 +71,9 @@ function parsePreflightArgs(argv = []) {
       options.help = true;
     } else if (arg === '--skip-p2p-dialback') {
       options.skipP2pDialback = true;
+    } else if (arg === '--local-only') {
+      options.localOnly = true;
+      options.skipP2pDialback = true;
     } else if (arg === '--require-p2p-dialback') {
       options.requireP2pDialback = true;
     } else if (arg.startsWith('--network=')) {
@@ -71,6 +82,8 @@ function parsePreflightArgs(argv = []) {
       options.ipfsCid = arg.slice('--ipfs-cid='.length);
     } else if (arg.startsWith('--ipfs-sha256=')) {
       options.ipfsSha256 = arg.slice('--ipfs-sha256='.length);
+    } else if (arg.startsWith('--canary-envs=')) {
+      options.canaryEnvsDir = arg.slice('--canary-envs='.length);
     } else {
       throw makeConfigError(
         'PREFLIGHT_UNSUPPORTED_ARGUMENT',
@@ -114,6 +127,8 @@ function renderHelp() {
     '  --ipfs-sha256=<sha256>       Override PREFLIGHT_IPFS_SHA256.',
     '  --skip-p2p-dialback          Do not attempt optional external dial-back probe.',
     '  --require-p2p-dialback       Fail if no dial-back probe is configured or reachable.',
+    '  --canary-envs=<dir>          Validate generated canary operator manifest and env files.',
+    '  --local-only                 Skip P2P dial-back and allow private multiaddrs in canary envs.',
     '',
   ].join('\n');
 }
@@ -562,6 +577,19 @@ function buildRedisConnection(env) {
   return redis;
 }
 
+function buildPreflightQueueName(env = process.env) {
+  const baseName = env.QUEUE_NAME || 'venom-campaigns';
+  const suffix = String(env.OPERATOR_QUEUE_SUFFIX || '').trim();
+  if (!suffix) return baseName;
+  if (!/^[a-zA-Z0-9._-]{1,64}$/.test(suffix)) {
+    throw makeConfigError(
+      'PREFLIGHT_QUEUE_SUFFIX_INVALID',
+      'OPERATOR_QUEUE_SUFFIX must be 1-64 characters using only letters, numbers, dot, underscore, or dash'
+    );
+  }
+  return `${baseName}-${suffix}`;
+}
+
 function buildLiveClientOptions(context, parsed, env = process.env) {
   const rpcUrls = buildRpcUrls(env);
   if (!rpcUrls.length) {
@@ -575,7 +603,7 @@ function buildLiveClientOptions(context, parsed, env = process.env) {
   const registry = new ethers.Contract(registryAddress, REGISTRY_ABI, provider);
   const escrow = new ethers.Contract(escrowAddress, ESCROW_ABI, provider);
   const redisClient = buildRedisConnection(env);
-  const queue = new Queue(env.QUEUE_NAME || 'venom-campaigns', { connection: redisClient });
+  const queue = new Queue(buildPreflightQueueName(env), { connection: redisClient });
   const mlClient = createMlHttpClient(env);
 
   return {
@@ -637,6 +665,12 @@ function printPreflightOutput({ context, report, paths }) {
   console.log(`Report: ${markdownPath}`);
 }
 
+function isBlockingPreflightPhase(phase, parsed = {}) {
+  if (phase.state === STATE.FAIL) return true;
+  if (phase.state !== STATE.SKIP) return false;
+  return !(parsed.canaryEnvsDir && phase.index === 7);
+}
+
 async function main(argv = process.argv.slice(2), env = process.env) {
   let parsed;
   let context;
@@ -660,7 +694,11 @@ async function main(argv = process.argv.slice(2), env = process.env) {
       network: parsed.network,
       chainId: SUPPORTED_NETWORKS[parsed.network].chainId,
       readOnly: true,
+      canaryEnvsDir: parsed.canaryEnvsDir,
+      localOnly: parsed.localOnly,
     };
+    context.canaryEnvsDir = parsed.canaryEnvsDir;
+    context.localOnly = parsed.localOnly;
     context.safety = {
       touchesLiveState: true,
       maySpendTestnetEth: false,
@@ -674,7 +712,26 @@ async function main(argv = process.argv.slice(2), env = process.env) {
       env,
     });
 
-    const hasBlockingPhase = phases.some((phase) => phase.state === STATE.FAIL || phase.state === STATE.SKIP);
+    let hasBlockingPhase = phases.some((phase) => isBlockingPreflightPhase(phase, parsed));
+    if (!hasBlockingPhase && parsed.canaryEnvsDir) {
+      const canaryPhase = await runCanaryReadiness(context, {
+        canaryEnvsDir: parsed.canaryEnvsDir,
+        localOnly: parsed.localOnly,
+        env,
+        provider: resources.provider,
+        registry: resources.registry,
+        escrow: resources.escrow,
+        registryAddress: env.VENOM_REGISTRY_ADDRESS,
+        escrowAddress: env.PILOT_ESCROW_ADDRESS,
+      });
+      const reportIndex = phases.findIndex((phase) => phase.key === 'report');
+      if (reportIndex >= 0) {
+        phases.splice(reportIndex, 0, canaryPhase);
+      } else {
+        phases.push(canaryPhase);
+      }
+      hasBlockingPhase = phases.some((phase) => isBlockingPreflightPhase(phase, parsed));
+    }
     if (!hasBlockingPhase) {
       const gateResult = await runLivePreflightGates(resources, { env, parsed });
       applyLivePreflightGates(phases, gateResult);
@@ -738,6 +795,8 @@ module.exports = {
   runP2pDialbackCheck,
   runLivePreflightGates,
   applyLivePreflightGates,
+  buildPreflightQueueName,
+  isBlockingPreflightPhase,
   buildLiveClientOptions,
   main,
 };

--- a/scripts/pilot/smoke-test.js
+++ b/scripts/pilot/smoke-test.js
@@ -31,6 +31,7 @@ const FIXTURE_ESCROW_BYTECODE =
 const FIXTURE_REGISTRY_BYTECODE =
   `0x608060405234801561001057600080fd5b5063${SELECTORS.UNSTAKE.slice(2)}600052`;
 const FIXTURE_ORACLE_COUNT = 3;
+const CORE_PHASES = PHASES.filter((phase) => phase.key !== 'canary');
 
 function makeSkeletonPhaseResult(phase) {
   return createPhaseResult(phase.index, STATE.SKIP, {
@@ -49,8 +50,8 @@ function makeSkippedPhaseResult(phase, triggerPhase) {
   });
 }
 
-function cascadeRest(results, triggerPhase, sliceFrom, sliceTo = PHASES.length - 1) {
-  for (const phase of PHASES.slice(sliceFrom, sliceTo)) {
+function cascadeRest(results, triggerPhase, sliceFrom, sliceTo = CORE_PHASES.length - 1) {
+  for (const phase of CORE_PHASES.slice(sliceFrom, sliceTo)) {
     results.push(makeSkippedPhaseResult(phase, triggerPhase));
   }
 }
@@ -234,7 +235,7 @@ async function runCistPhases(context, options = {}) {
   }
 
   if (effectiveState(phase6, strict) !== STATE.PASS) {
-    for (const phase of PHASES.slice(results.length, PHASES.length - 1)) {
+    for (const phase of CORE_PHASES.slice(results.length, CORE_PHASES.length - 1)) {
       results.push(makeSkeletonPhaseResult(phase));
     }
 


### PR DESCRIPTION
## [Canary 01.5] Module D + MF-5 + MF-8: Canary-readiness preflight

This is PR 4 of 8 in the Canary 01.5 integration series.

**Scope.** Adds CIST phase 9 (canary readiness), wires the `--canary-envs=<dir>`
flag through preflight.js, fixes two preflight regressions discovered during
Canary 01.5 (MF-5 and MF-8), and adds focused tests for all three.

**Phase 9: canary readiness.** When `--canary-envs=<dir>` is provided, the
preflight loads the operator manifest from `<dir>/manifest.json` and runs
seven gates against it:

| Gate | Code | Checks |
|---|---|---|
| Profile match | `CANARY_PROFILE_MISMATCH` | On-chain immutables match `profile.constants` |
| Deployment match | `CANARY_DEPLOYMENT_MISMATCH` | Manifest contract addresses match shell exports |
| Queue suffix validity | `CANARY_QUEUE_SUFFIX_INVALID` | Each suffix passes the regex |
| Operator-deployer collision | `CANARY_OPERATOR_IS_DEPLOYER` | No operator key equals the deployer key |
| Private multiaddr | `CANARY_PRIVATE_MULTIADDR` | No operator advertises a private multiaddr (`--local-only` opts out) |
| Operator balance | `CANARY_OPERATOR_BALANCE_LOW` | Each operator wallet ≥ `MIN_STAKE + buffer` |
| Suffix uniqueness | (manifest property) | All operator suffixes are distinct |

Phase 9 returns `SKIP` cleanly when `--canary-envs` is not provided, so the
existing single-operator preflight UX is unchanged.

**MF-5: phase 7 (legacy single-operator p2p preflight) skips operator-wallet
gates when `--canary-envs` is active.** Previously phase 7 derived an
"operator" identity from `OPERATOR_PRIVATE_KEY` and reported a FAIL when the
env was legitimately unset (canary mode delegates this to phase 9). Now phase
7's operator-derived gates emit `SKIP` with a note when `--canary-envs` is
present, and the preflight orchestrator does not treat that SKIP as blocking
phase 9 or the run summary.

**MF-8: live preflight queue construction honors `OPERATOR_QUEUE_SUFFIX`.**
Previously preflight constructed `new Queue(env.QUEUE_NAME || 'venom-campaigns', ...)`,
which never picked up the operator suffix and therefore tested an unsuffixed
queue that no operator actually used. Now `buildPreflightQueueName(env)`
applies the same regex-validated suffix that `aggregator/queue.js` uses, so
preflight tests the same queue the worker runs against.

**Localization decision.** `canary-readiness.js` defines `PROFILE_CONSTANTS`
and `QUEUE_SUFFIX_PATTERN` locally rather than importing from PR 2's
`aggregator/queue.js` or PR 3's `make-operator-envs.js`. Reason: PR 4 must
review and merge independently against `main`. Values are verified identical
to the canonical sources; future consolidation tracked as MF-9 in the backlog
(land after all 8 integration PRs merge).

**New CIST tests:** `canary-readiness.test.js` covers all 7 gates plus
manifest validation edge cases. `preflight.test.js` adds 4 new tests for
the new helpers (registry ABI guard, `buildPreflightQueueName` MF-8 regression,
phase-7-as-non-blocking MF-5 regression). `p2p-aggregation.test.js` adds 1
test for MF-5 skip behavior.

**Out of scope (handled in subsequent PRs):**
- ML service `/ready` endpoint and healthcheck → PR 5a
- Test-file regression coverage for the underlying main fixes (test/deploy_phase4.test.js, etc.) → PR 5b
- Module G partial bootstrap envs (which phase 9 will eventually validate too — that's PR 7's expansion of phase 9 tests)

**Test counts:**
- `npm test` (Hardhat): 72 passing on main → 72 passing on PR 4 branch (no Hardhat test changes)
- `npm run test:cist`: <baseline> passing on main → 237 passing on PR 4 branch (+25 new, 1 pending)
- `node scripts/check-js.js`: 72 JS files, clean

**Verification:**
- `npm install`: passed
- `npm run compile`: clean
- `npm test`: 72 passing
- `npm run test:cist`: 237 passing, 1 pending
- `node scripts/check-js.js`: 72 files, clean

Refs Canary 01.5 (run window 2026-05-08), MF-5, MF-8.