### PR TITLE
[Canary 01.5] ML service readiness

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=5)"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/ready', timeout=5)"]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/ml_service/README.md
+++ b/ml_service/README.md
@@ -15,6 +15,12 @@ Health check:
 curl http://127.0.0.1:8000/health
 ```
 
+Readiness check after the semantic model is loaded:
+
+```bash
+curl http://127.0.0.1:8000/ready
+```
+
 Evaluation endpoint:
 
 ```bash

--- a/ml_service/main.py
+++ b/ml_service/main.py
@@ -157,6 +157,23 @@ async def health_check(request: Request):
     }
 
 
+@app.get("/ready", dependencies=[Depends(optional_verify_api_key)])
+@limiter.limit("30/minute")
+async def readiness_check(request: Request):
+    api_key_configured = bool(os.getenv("ML_SERVICE_API_KEY"))
+    model_loaded = hasattr(app.state, "semantic_model")
+    if requires_api_key() and not api_key_configured:
+        raise HTTPException(status_code=503, detail="ML_SERVICE_API_KEY is required in testnet/mainnet mode")
+    if not model_loaded:
+        raise HTTPException(status_code=503, detail="Semantic model is not loaded")
+    return {
+        "status": "ready",
+        "model_loaded": model_loaded,
+        "model_name": SEMANTIC_MODEL_NAME,
+        "api_key_configured": api_key_configured
+    }
+
+
 @app.post("/evaluate", response_model=EvaluateResponse, dependencies=[Depends(verify_api_key)], tags=["evaluation"])
 @limiter.limit("10/minute")
 async def evaluate(request: Request, evaluate_request: EvaluateRequest):


### PR DESCRIPTION
## [Canary 01.5] ML service readiness

This is PR 5a of 8 in the Canary 01.5 integration series.

**Scope.** Adds a `/ready` endpoint to the ML service and points the
docker-compose healthcheck at it. Documents the endpoint in the ML service
README.

**Why this matters.** During canary startup the ML service takes 30-60 seconds
to load `sentence-transformers/all-MiniLM-L6-v2` into memory. Without a
readiness probe distinct from `/health`, dependent services (e.g.
venom-node-canary-N waiting on `ml-service-canary` to be healthy) had to
either guess a startup delay or fail randomly during the first wave of
requests. The `/ready` endpoint makes "model loaded and ready to serve" an
explicit signal.

**Readiness semantics.** `/ready` returns 503 in either of two cases:
- The semantic model is not yet loaded into `app.state`
- API key auth is required (testnet/mainnet runtime modes) but
  `ML_SERVICE_API_KEY` is unset

When both conditions clear, the endpoint returns 200 with status, model name,
and API-key configuration state.

This dual gating is intentional: in testnet mode without an API key set, the
service is technically running but cannot accept evaluation requests; calling
it "ready" would mislead orchestration. The sentinel-value rejection
(`replace-me-with-a-random-32-byte-hex-value`) is enforced separately at
request time and tested in PR 5b's pytest suite.

**Auth.** `/ready` uses `optional_verify_api_key` — the healthcheck itself
does not need to authenticate. Rate-limited to 30/minute.

**Docker healthcheck.** Compose now points `ml-service` at
`http://127.0.0.1:8000/ready` with a 5-second timeout. Operator services
that `depends_on: { ml-service: { condition: service_healthy } }` will only
start after the readiness signal flips.

**Out of scope (handled in subsequent PRs):**
- pytest plumbing and `ml_service/tests/test_api_key.py` regression tests → PR 5b
- `scripts/check-js.js` ignored-dirs additions for `.pytest_cache/` and `__pycache__/` → PR 5b (lands with the pytest plumbing it serves)

**Test counts:**
- `npm test`: 72 passing on main → 72 passing on PR 5a branch (no JS test changes)
- `python -m py_compile ml_service/main.py`: clean
- `node scripts/check-js.js`: 70 JS files, clean

**Verification:**
- `npm install`: passed
- `npm run compile`: clean
- `npm test`: 72 passing
- `node scripts/check-js.js`: 70 files, clean
- `python -m py_compile ml_service/main.py`: clean

Refs Canary 01.5 (run window 2026-05-08), MAIN-FIX-10.