### PR TITLE
[Canary 01.5] Documentation

### DIFF
--- a/docs/CANARY_01_5.md
+++ b/docs/CANARY_01_5.md
@@ -1,0 +1,115 @@
+# Canary 01.5 - Reduced-Economic Multi-Operator Canary
+
+**Status:** proposed next canary.
+**Purpose:** validate multi-operator behavior before locking 5 ETH testnet stake.
+**Disclosure:** this is not production-equivalent. It uses reduced stake and adjusted quorum constants so the run can stay near 1 total testnet ETH.
+
+## Why This Exists
+
+Canary 01 proved the solo close loop against real Base Sepolia infrastructure. It deliberately did not prove the distributed paths:
+
+- multi-signer EIP-712 aggregation
+- real peer-to-peer gossip propagation
+- non-trivial median calculation
+- leader failover between operators
+- mixed score/abstain participation
+- escrow-triggered deviation slashing
+
+Canary 02 should eventually use production economics: 5 wallets with 1 ETH stake each. Canary 01.5 exists to de-risk that run with lower testnet ETH exposure.
+
+## Recommended Profile
+
+| Parameter | Value |
+|---|---:|
+| Chain | Base Sepolia |
+| Operators | 5 fresh hot wallets |
+| Stake per operator | 0.1 ETH |
+| Total stake locked | 0.5 ETH |
+| Suggested wallet balance | 0.16-0.20 ETH each |
+| `REQUIRED_ORACLES` | 3 |
+| `SCORE_QUORUM_PCT` | 50 |
+| `PARTICIPATION_FLOOR_PCT` | 67 |
+| `CAMPAIGN_TIMEOUT_BLOCKS` | 3600 for iteration, or 7200 for closer production soak |
+| ML path | real evaluator, no force-pass |
+| Payload path | real CID plus hash verification |
+
+Expected total capacity: about 0.8-1.0 testnet ETH, including locked stake, deployment gas, close/cancel gas, and small campaign bounties.
+
+Deploy the contracts with `DEPLOY_PROFILE=canary-01-5` so `MIN_STAKE`, `REQUIRED_ORACLES`, and timeout constants match this table. The production profile remains the default when `DEPLOY_PROFILE` is unset or set to `production`.
+
+## Non-Negotiable Setup Rules
+
+- Use fresh hot wallets only. Do not use a deployer, holding, or cold wallet key.
+- `DEPLOYER_PRIVATE_KEY` must not be present in operator runtimes.
+- `USE_TEST_PAYLOAD=false`.
+- `ML_SERVICE_API_KEY` must be a real non-sentinel secret.
+- Run live preflight with `PREFLIGHT_IPFS_CID` and `PREFLIGHT_IPFS_SHA256` set.
+- Run `npm run pilot:preflight -- --network=base-sepolia --canary-envs=.venom-canary` before funding campaign bounties. Phase 7 is skipped automatically in multi-operator mode and Phase 9 owns canary readiness.
+- Require public P2P dial-back unless the run is explicitly local-only.
+- Preserve all deployment artifacts, logs, postcards, and dashboard snapshots.
+
+## Operator Env Generation
+
+After deploying with `DEPLOY_PROFILE=canary-01-5`, generate isolated local operator environments from the deployment artifact:
+
+```bash
+npm run pilot:operator-envs -- --count=5 --deployment=deployments/base-sepolia.json --out=.venom-canary --profile=canary-01-5
+```
+
+This writes `.venom-canary/operator-*/.env`, `.venom-canary/manifest.json`, `.venom-canary/funding-targets.txt`, and `docker-compose.canary-01-5.yml`. The `.venom-canary/` directory contains private keys and is ignored by git.
+
+Use `funding-targets.txt` to fund the five generated hot wallets. Then run the generated compose file with a separate project name so it does not collide with the single-node dev stack:
+
+```bash
+docker compose --project-name canary -f docker-compose.canary-01-5.yml up -d --build
+```
+
+Before funding campaign bounties, run live preflight against the generated manifest:
+
+```bash
+npm run pilot:preflight -- --network=base-sepolia --canary-envs=.venom-canary
+```
+
+For a local-only rehearsal that intentionally uses private multiaddrs, add `--local-only`. Canary preflight checks generated operator balances, deployment/profile constants, queue suffix uniqueness, deployer/operator address separation, and private-multiaddr exposure.
+
+## Queue Isolation
+
+Do not run five local operator processes against one shared BullMQ queue name without per-operator isolation. With one shared queue, only one worker may receive a campaign job, which means only one operator signs.
+
+For a local multi-operator canary on one Redis instance, use the same `QUEUE_NAME` and set a unique `OPERATOR_QUEUE_SUFFIX` in each operator environment:
+
+| Operator | `QUEUE_NAME` | `OPERATOR_QUEUE_SUFFIX` |
+|---|---|---|
+| op1 | `venom-campaigns` | `op1` |
+| op2 | `venom-campaigns` | `op2` |
+| op3 | `venom-campaigns` | `op3` |
+| op4 | `venom-campaigns` | `op4` |
+| op5 | `venom-campaigns` | `op5` |
+
+The suffix creates a distinct BullMQ queue and scopes the producer cursor plus queued-campaign marker for that operator. Isolated Redis databases or instances are still acceptable, but the suffix is the lowest-friction setup for Canary 01.5.
+
+## Scenario Matrix
+
+Run 6-10 small campaigns:
+
+| Scenario | Expected Result |
+|---|---|
+| All 5 score | Clean close; on-chain median matches submitted scores. |
+| 3 score, 2 abstain | Clean close under `REQUIRED_ORACLES=3`; participation passes. |
+| 2 score, 3 abstain | Close must fail below absolute score floor. |
+| One score outlier beyond `MAX_DEVIATION` | Campaign closes and deviant oracle is slashed. |
+| Hash mismatch | Workers publish signed `HashMismatch` abstains; no invalid score is signed. |
+| Round-0 leader stopped | A later leader submits after `P2P_LEADER_TIMEOUT_MS`. |
+
+## Success Criteria
+
+- At least 5 successful closes.
+- At least one observed leader failover.
+- At least one escrow-triggered `OracleSlashed` event.
+- Dashboard/Quorum Replay shows multiple observed signers.
+- Campaign Postcards are written for successful closes.
+- Cost accounting separates spent gas, cancelled-campaign fees, locked stake, and stake recoverable after cooldown.
+
+## Documentation Note
+
+Real payload fetching and hash verification are implemented and solo-canary proven, including an observed `HashMismatch` abstain in Canary 01. They are not yet proven under a multi-operator canary.

--- a/docs/CANARY_BACKPORT_TRACKING.md
+++ b/docs/CANARY_BACKPORT_TRACKING.md
@@ -1,0 +1,34 @@
+# Canary Backport Tracking
+
+This file records the Canary 01 issues referenced by `docs/CANARY_01_RESULTS.md`. It is intentionally concise; detailed reproduction notes should be appended as regressions are added.
+
+## MAIN-FIX Summary
+
+| ID | Severity | Component | Status | Regression Target |
+|---|---|---|---|---|
+| MAIN-FIX-1 | Medium | `aggregator/p2p.js` | Backported | gossipsub `emitSelf: true` for solo/self-observed signatures |
+| MAIN-FIX-2 | High | `scripts/pilot/preflight.js` | Backported | `oracles(address)` ABI returns 6 fields |
+| MAIN-FIX-3 | Low | `aggregator/p2p.js` | Backported | active-oracle refresh handles missing iterable values |
+| MAIN-FIX-4 | Medium | `scripts/deploy_phase4.js` | Backported | public-network bind transaction waits 3 confirmations and readback retries |
+| MAIN-FIX-5 | High | `Dockerfile`, `package.json`, CI | Backported | Node 22 runtime requirement |
+| MAIN-FIX-6 | Medium | `aggregator/queue.js`, preflight, env | Backported | Redis username defaults to `venom_node` |
+| MAIN-FIX-7 | Low | `register_and_start.js` | Backported | deployer key rejection gives remediation text |
+| MAIN-FIX-8 | Low | `hardhat.config.js`, `.env.example` | Backported | Etherscan V2 single API key |
+| MAIN-FIX-9 | Low | `register_and_start.js`, docs | Backported | explicit solo-only private multiaddr escape hatch |
+| MAIN-FIX-10 | Medium | `ml_service/main.py`, `.env.example` | Backported | testnet/mainnet reject missing or sentinel ML API key |
+| MAIN-FIX-11 | Low | `aggregator/p2p.js` | Backported | node does not continuously re-dial its own multiaddr |
+| MAIN-FIX-12 | Low | `Dockerfile` | Backported | `/app/.venom-artifacts` exists and is writable by `node` |
+
+## Next Regression Pass
+
+When touching affected code, add focused tests tagged with comments such as:
+
+```js
+// Regression: MAIN-FIX-6
+```
+
+Prioritize MAIN-FIX-1, MAIN-FIX-2, MAIN-FIX-5, MAIN-FIX-6, MAIN-FIX-10, and MAIN-FIX-12 because these either blocked operators or only surfaced against real infrastructure.
+
+## Canary-Only Changes
+
+The Canary 01 checkout used relaxed constants and `CANARY_FORCE_PASS=true`. These were canary-only shortcuts and must not be treated as production defaults.

--- a/docs/IMPROVEMENT_BACKLOG.md
+++ b/docs/IMPROVEMENT_BACKLOG.md
@@ -31,11 +31,25 @@ Source reports reviewed: Multiple internal review reports across iterative revie
 
 ## Next Iteration Candidates
 
+### Canary 01.5 Integration Findings
+
+| ID | Status | Follow-up |
+|---|---|---|
+| MF-1 | Closed in integration PR 7 | Keep runtime quorum reads fail-closed. If `PilotEscrow` constants cannot be read, the aggregator must not fall back to optimistic defaults before aggregate submission. |
+| MF-2 | Closed in integration PR 7 | Preserve leader failover behavior under timeout so a later eligible signer can submit when the first leader stalls. |
+| MF-3 | Closed in integration PR 7 | Keep off-chain aggregation gates aligned with configurable on-chain quorum constants, including required score count, score quorum percentage, and participation floor. |
+| MF-4 | Closed in integration PR 3 | Treat generated canary operator envs, manifests, funding targets, and compose files as artifacts. Keep `.venom-canary/` ignored and regenerate per run. |
+| MF-5 | Closed in integration PR 4 | Skip the legacy single-operator Phase 7 P2P preflight when `--canary-envs` is active; Phase 9 owns multi-operator readiness. |
+| MF-6 | Closed in integration PR 2 | Keep BullMQ queue names using the hyphenated operator suffix form, while Redis keys continue using colon separators. BullMQ rejects colon-bearing queue names. |
+| MF-7 | Deferred to Canary 02 | Replace the Canary 01.5 bootstrap workaround with persistent per-operator libp2p keys, stable peer IDs, and a governed or operator-authenticated registry method to update oracle multiaddrs without redeploying the registry. |
+| MF-8 | Closed in integration PR 4 | Ensure live preflight queue construction honors `OPERATOR_QUEUE_SUFFIX` so multi-operator preflight validates the queue names operators actually use. |
+| MF-9 | Deferred, P3 | Consolidate canary profile constants and the queue suffix validation regex into a shared module. PR 4 intentionally localized these values to stay independent, but future edits should avoid duplicating profile policy across scripts and tests. |
+
 ### Protocol And Contract Design
 
 - Upgrade signer-set-derived off-chain leader selection to a full commit-reveal design, then VRF. The current bridge reduces funder predictability but is not a final unbiasable randomness scheme.
 - Consider optional on-chain leader enforcement only if leader gas reimbursement or stronger submitter attribution becomes necessary.
-- Implement real payload identity: campaign events need content metadata, and workers need CID/multihash verification before scoring. `HashMismatch` exists as a reason but is not yet produced.
+- Extend real payload identity beyond the current CID/content-hash path: Canary 01 proved worker-side `HashMismatch` abstains against real chain state, but multi-oracle runs still need CID/multihash behavior proven under mesh conditions and richer content metadata if the campaign model expands.
 - Address campaign UID squatting by deriving campaign IDs from funder, salt, and content hash or by adding a reservation/commit flow.
 - Add oracle unstaking and deregistration with a cooldown, slash eligibility during cooldown, and clear operator exit docs.
 - Add a slashing dispute window before slashes become withdrawable.

--- a/docs/OPERATOR_GUIDE.md
+++ b/docs/OPERATOR_GUIDE.md
@@ -41,6 +41,10 @@ Use a dedicated low-balance hot wallet. Do not use a primary wallet, cold-storag
 
 For solo, non-production tests on machines without public P2P reachability, set `VENOM_ALLOW_PRIVATE_MULTIADDR=true` to register the node's private libp2p multiaddr. The node logs a warning when this path is used. Do not use it for production pilots; production operators should configure `PUBLIC_MULTIADDR` or port forwarding so other oracles can dial the node.
 
+## Deployment Profiles
+
+Deployments can set `DEPLOY_PROFILE=production`, `DEPLOY_PROFILE=canary-01-5`, or `DEPLOY_PROFILE=solo`. The profile selects bounded constructor values for `VenomRegistry.MIN_STAKE()` and the `PilotEscrow` quorum/timeout getters. `production` is the default when the variable is unset. Runtime operators should read the deployed contract values instead of assuming 5 required oracles or a 1 ETH stake.
+
 ## Monitoring
 
 ```bash
@@ -50,7 +54,7 @@ docker compose logs -f ml-service
 
 ## Current Economics
 
-- Stake required by the current registry: `1 ETH` on testnet.
+- Stake required by the current registry: read `VenomRegistry.MIN_STAKE()`. The default `production` deploy profile uses `1 ETH`; `canary-01-5` uses `0.1 ETH`.
 - Current slash amount: `5%` of registered stake for score deviation beyond `MAX_DEVIATION`.
 - Operator bounty payouts are not implemented in the active `PilotEscrow` contract. The current campaign bounty is returned to the campaign recipient recorded at funding time, which is currently the funder.
 - Unstaking is implemented with `requestUnstake()` followed by `finalizeUnstake()` after a 7-day cooldown. An oracle can still be slashed during the cooldown, and slashed oracles cannot re-register after finalization.
@@ -67,7 +71,7 @@ Running a modified node that signs invalid scores can cause the oracle to be mar
 - Confirm `ML_SERVICE_API_KEY` is not the `.env.example` sentinel value.
 - Set `PREFLIGHT_IPFS_CID` and `PREFLIGHT_IPFS_SHA256` to a small known public payload.
 - Confirm `DEPLOYER_PRIVATE_KEY` is not present in the operator environment.
-- Confirm at least 5 active oracles before funding a campaign against the default escrow constants.
+- Confirm active oracle count is at least `PilotEscrow.REQUIRED_ORACLES()` before funding a campaign.
 - Run the read-only live preflight before funding:
 
 ```bash


### PR DESCRIPTION
## [Canary 01.5] Documentation

This is PR 8 of 8 — the final PR in the Canary 01.5 integration series.

**Scope.** Adds and updates the documentation that frames the Canary 01.5 cycle:
- `docs/CANARY_01_5.md` (new) — canary plan, profile description, scenario matrix, and pre-fund checklist
- `docs/CANARY_BACKPORT_TRACKING.md` (new) — the MAIN-FIX backport tracker for the cycle's main-branch fixes
- `docs/IMPROVEMENT_BACKLOG.md` (modified) — appends MF-1 through MF-9 with closed/deferred status per integration PR
- `docs/OPERATOR_GUIDE.md` (modified) — additions for canary deploy profiles and configurable constants

**MF status table** (now in IMPROVEMENT_BACKLOG.md):

| ID | Status | Where it landed |
|---|---|---|
| MF-1, MF-2, MF-3 | Closed | PR 7 (Module G partial: bootstrap peer discovery covers fail-closed quorum reads, leader failover, off-chain quorum alignment) |
| MF-4 | Closed | PR 3 (operator env generator + .gitignore additions) |
| MF-5 | Closed | PR 4 (preflight phase 7 skips when --canary-envs active) |
| MF-6 | Closed | PR 2 (BullMQ queue name colon → hyphen) |
| MF-7 | **Deferred** | Canary 02 — needs persistent libp2p keys + registry update method + on-chain correction |
| MF-8 | Closed | PR 4 (preflight buildQueueName respects OPERATOR_QUEUE_SUFFIX) |
| MF-9 | Deferred (P3) | Code-quality follow-up after integration cycle completes |

**Out of scope (intentional holds):**
- `docs/CANARY_01_5_RESULTS.md` — separate post-integration doc PR (the canary's findings document)
- `.env.example` deploy/runtime partition — separate doc improvement PR informed by Canary 01.5's findings; not a canary cycle deliverable

**Test counts:** unchanged (this PR is docs-only).

**Verification:**
- `npm run compile`: clean
- `npm test`: 72 passing (no test changes)
- `node scripts/check-js.js`: 70 JS files, clean

Refs Canary 01.5 (run window 2026-05-08).