### PR TITLE
[Canary 01.5] Module B: Queue isolation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,8 +104,10 @@ CLOSE_GAS_LIMIT=
 CLOSE_MAX_FEE_GWEI=
 CLOSE_MAX_PRIORITY_FEE_GWEI=
 
-# Redis queue name (for multi-node deployments)
+# Redis queue name. For local multi-operator canaries on one Redis instance,
+# keep QUEUE_NAME shared and set a unique OPERATOR_QUEUE_SUFFIX per operator.
 QUEUE_NAME=venom-campaigns
+OPERATOR_QUEUE_SUFFIX=
 
 # Health endpoint
 HEALTH_PORT=3000

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build/
 dist/
 artifacts/
 cache/
+deployments/
 __pycache__/
 *.pyc
 attack_runs/

--- a/aggregator/producer.js
+++ b/aggregator/producer.js
@@ -1,5 +1,5 @@
 // aggregator/producer.js
-const { getCampaignQueue, getConnection } = require('./queue');
+const { getCampaignQueue, getConnection, operatorScopedKey, QUEUE_NAME, OPERATOR_QUEUE_SUFFIX } = require('./queue');
 const { ethers } = require('ethers');
 const MultiRpcProvider = require('../rpc/router');
 const path = require('path');
@@ -44,7 +44,7 @@ function getProducerRuntime() {
 
 function getCursorKey() {
   const address = process.env.PILOT_ESCROW_ADDRESS || "unknown";
-  return `venom:producer:lastScannedBlock:${address.toLowerCase()}`;
+  return operatorScopedKey("producer", "lastScannedBlock", address.toLowerCase());
 }
 
 async function loadLastScannedBlock() {
@@ -122,7 +122,7 @@ async function discoverAndQueueNewCampaigns() {
       const uid = event.args.campaignUid;
       const contentUri = event.args.contentUri;
       const contentHash = event.args.contentHash;
-      const campaignKey = `venom:campaign:queued:${uid.toLowerCase()}`;
+      const campaignKey = operatorScopedKey("campaign", "queued", uid.toLowerCase());
 
       const exists = await getConnection().exists(campaignKey);
       if (exists) {
@@ -162,7 +162,8 @@ async function discoverAndQueueNewCampaigns() {
 
 async function startProducer() {
   console.log("Starting VENOM Producer (BullMQ + MultiRPC)");
-  console.log(`   Contract: ${process.env.PILOT_ESCROW_ADDRESS}\n`);
+  console.log(`   Contract: ${process.env.PILOT_ESCROW_ADDRESS}`);
+  console.log(`   Queue: ${QUEUE_NAME}${OPERATOR_QUEUE_SUFFIX ? ` (operator suffix: ${OPERATOR_QUEUE_SUFFIX})` : ""}\n`);
 
   await discoverAndQueueNewCampaigns();
   producerInterval = setInterval(discoverAndQueueNewCampaigns, 30000);

--- a/aggregator/queue.js
+++ b/aggregator/queue.js
@@ -12,7 +12,32 @@ const REDIS_USERNAME = process.env.REDIS_USERNAME || 'venom_node';
 const REDIS_PASSWORD = process.env.REDIS_PASSWORD || undefined;
 const REDIS_TLS = process.env.REDIS_TLS === 'true';
 
-const QUEUE_NAME = process.env.QUEUE_NAME || 'venom-campaigns';
+const BASE_QUEUE_NAME = process.env.QUEUE_NAME || 'venom-campaigns';
+
+function normalizeQueueSuffix(input) {
+  const suffix = String(input || '').trim();
+  if (!suffix) return '';
+  if (!/^[a-zA-Z0-9._-]{1,64}$/.test(suffix)) {
+    throw new Error('OPERATOR_QUEUE_SUFFIX must be 1-64 characters using only letters, numbers, dot, underscore, or dash');
+  }
+  return suffix;
+}
+
+const OPERATOR_QUEUE_SUFFIX = normalizeQueueSuffix(process.env.OPERATOR_QUEUE_SUFFIX);
+
+function buildQueueName(baseName = BASE_QUEUE_NAME, suffix = OPERATOR_QUEUE_SUFFIX) {
+  const normalizedSuffix = normalizeQueueSuffix(suffix);
+  return normalizedSuffix ? `${baseName}-${normalizedSuffix}` : baseName;
+}
+
+function operatorScopedKey(...parts) {
+  const scopedParts = OPERATOR_QUEUE_SUFFIX
+    ? ['venom', OPERATOR_QUEUE_SUFFIX, ...parts]
+    : ['venom', ...parts];
+  return scopedParts.map((part) => String(part)).join(':');
+}
+
+const QUEUE_NAME = buildQueueName();
 
 let connection = null;
 let campaignQueue = null;
@@ -102,5 +127,10 @@ module.exports = {
   closeQueueResources,
   reconnectRedis,
   redisEventEmitter,
+  BASE_QUEUE_NAME,
+  OPERATOR_QUEUE_SUFFIX,
+  normalizeQueueSuffix,
+  buildQueueName,
+  operatorScopedKey,
   QUEUE_NAME
 };

--- a/aggregator/worker.js
+++ b/aggregator/worker.js
@@ -2,7 +2,7 @@
 // VENOM Node v1.1.0-rc.1 - IPFS fetch fallback, ML scoring, signed score/abstain gossip.
 
 const { Worker } = require('bullmq');
-const { getConnection, QUEUE_NAME } = require('./queue');
+const { getConnection, QUEUE_NAME, OPERATOR_QUEUE_SUFFIX } = require('./queue');
 const { ethers } = require('ethers');
 const path = require('path');
 const MultiRpcProvider = require('../rpc/router');
@@ -471,7 +471,8 @@ async function startWorker() {
   });
 
   console.log("Starting VENOM Worker v1.1.0 (BullMQ + signed abstention + IPFS concurrent fallback)");
-  console.log(`   Address: ${wallet.address} | Concurrency: ${WORKER_CONCURRENCY} | Gateways: ${IPFS_GATEWAYS.length} | ML: ${ML_SERVICE_URL}\n`);
+  console.log(`   Address: ${wallet.address} | Queue: ${QUEUE_NAME}${OPERATOR_QUEUE_SUFFIX ? ` | Queue suffix: ${OPERATOR_QUEUE_SUFFIX}` : ""}`);
+  console.log(`   Concurrency: ${WORKER_CONCURRENCY} | Gateways: ${IPFS_GATEWAYS.length} | ML: ${ML_SERVICE_URL}\n`);
 
   worker.on('failed', (job, err) => console.error(`Job ${job.id} failed:`, err.message));
   return worker;

--- a/contracts/PilotEscrow.sol
+++ b/contracts/PilotEscrow.sol
@@ -19,12 +19,12 @@ contract PilotEscrow is Ownable2Step, Pausable, ReentrancyGuard {
 
     uint256 private constant MAX_SCORES = 20;
     // === v1.1.0-rc.1 parameters ===
-    uint256 public constant REQUIRED_ORACLES = 5;
-    uint256 public constant SCORE_QUORUM_PCT = 50;          // BFT majority
-    uint256 public constant PARTICIPATION_FLOOR_PCT = 67;   // supermajority of network must have seen the campaign
+    uint256 public immutable REQUIRED_ORACLES;
+    uint256 public immutable SCORE_QUORUM_PCT;          // BFT majority
+    uint256 public immutable PARTICIPATION_FLOOR_PCT;   // supermajority of network must have seen the campaign
     uint256 public constant PASS_THRESHOLD = 60;
     uint256 public constant MAX_SCORE = 100;
-    uint256 public constant CAMPAIGN_TIMEOUT_BLOCKS = 7200; // ~4h on Base at ~2s blocks
+    uint256 public immutable CAMPAIGN_TIMEOUT_BLOCKS; // ~4h on Base at ~2s blocks
     uint256 public constant CANCEL_FEE_BPS = 100;           // 1% retained on cancel
     uint256 public constant WITHDRAWAL_TIMELOCK = 48 hours;
 
@@ -71,10 +71,32 @@ contract PilotEscrow is Ownable2Step, Pausable, ReentrancyGuard {
     event InsuranceWithdrawalExecuted(address indexed recipient, uint256 amount);
     /// @notice Emitted when the owner cancels a scheduled insurance pool withdrawal.
     event InsuranceWithdrawalCancelled(address indexed recipient);
+    /// @notice Emitted when a campaign close reports an oracle score deviation to the registry.
+    event DeviationReported(bytes32 indexed campaignUid, address indexed oracle, uint256 submittedScore, uint256 medianScore, uint256 deviation);
 
-    constructor(address _registry) Ownable(msg.sender) {
+    constructor(
+        address _registry,
+        uint256 _requiredOracles,
+        uint256 _scoreQuorumPct,
+        uint256 _participationFloorPct,
+        uint256 _campaignTimeoutBlocks
+    ) Ownable(msg.sender) {
         require(_registry != address(0), "Zero registry");
+        require(_requiredOracles >= 1 && _requiredOracles <= MAX_SCORES, "Invalid REQUIRED_ORACLES");
+        require(_scoreQuorumPct >= 1 && _scoreQuorumPct <= 100, "Invalid SCORE_QUORUM_PCT");
+        require(
+            _participationFloorPct >= _scoreQuorumPct && _participationFloorPct <= 100,
+            "Invalid PARTICIPATION_FLOOR_PCT"
+        );
+        require(
+            _campaignTimeoutBlocks >= 100 && _campaignTimeoutBlocks <= 50000,
+            "Invalid CAMPAIGN_TIMEOUT_BLOCKS"
+        );
         registry = VenomRegistry(_registry);
+        REQUIRED_ORACLES = _requiredOracles;
+        SCORE_QUORUM_PCT = _scoreQuorumPct;
+        PARTICIPATION_FLOOR_PCT = _participationFloorPct;
+        CAMPAIGN_TIMEOUT_BLOCKS = _campaignTimeoutBlocks;
     }
 
     function domainSeparator() public view returns (bytes32) {
@@ -166,6 +188,7 @@ contract PilotEscrow is Ownable2Step, Pausable, ReentrancyGuard {
                 ? validScores[i] - medianScore
                 : medianScore - validScores[i];
             if (deviation > maxDeviation) {
+                emit DeviationReported(campaignUid, validSigners[i], validScores[i], medianScore, deviation);
                 registry.reportDeviation(validSigners[i], validScores[i], medianScore);
             }
         }
@@ -269,10 +292,20 @@ contract PilotEscrow is Ownable2Step, Pausable, ReentrancyGuard {
     function _medianOfCopy(uint256[] memory src, uint256 count) internal pure returns (uint256) {
         require(count > 0, "Empty array");
         require(count <= MAX_SCORES, "Too many scores for median");
-        for (uint256 i = 1; i < count; i++) {
-            require(src[i] >= src[i - 1], "Scores not sorted");
+        uint256[] memory sorted = new uint256[](count);
+        for (uint256 i = 0; i < count; i++) {
+            sorted[i] = src[i];
         }
-        return src[count / 2];
+        for (uint256 i = 1; i < count; i++) {
+            uint256 key = sorted[i];
+            uint256 j = i;
+            while (j > 0 && sorted[j - 1] > key) {
+                sorted[j] = sorted[j - 1];
+                j--;
+            }
+            sorted[j] = key;
+        }
+        return sorted[count / 2];
     }
 
     /// @notice Schedule accumulated insurance pool withdrawal.

--- a/contracts/VenomRegistry.sol
+++ b/contracts/VenomRegistry.sol
@@ -43,9 +43,9 @@ contract VenomRegistry is Ownable2Step, ReentrancyGuard {
     address public pendingPilotEscrow;
     uint256 public pendingPilotEscrowScheduledAt;
 
-    uint256 public constant MIN_STAKE = 1 ether;
-    uint256 public constant SLASH_PERCENT = 5; // Reduced for rc.1
-    uint256 public constant MAX_DEVIATION = 25;
+    uint256 public immutable MIN_STAKE;
+    uint256 public immutable SLASH_PERCENT;
+    uint256 public immutable MAX_DEVIATION;
 
     /// @notice Emitted when an operator registers with stake and a Libp2p multiaddr.
     event OracleRegistered(address indexed operator, uint256 stake, string multiaddr);
@@ -70,7 +70,14 @@ contract VenomRegistry is Ownable2Step, ReentrancyGuard {
     /// @notice Emitted when a PilotEscrow upgrade is executed.
     event PilotEscrowUpgraded(address indexed newEscrow);
 
-    constructor() Ownable(msg.sender) {}
+    constructor(uint256 _minStake, uint256 _slashPercent, uint256 _maxDeviation) Ownable(msg.sender) {
+        require(_minStake >= 0.01 ether && _minStake <= 100 ether, "Invalid MIN_STAKE");
+        require(_slashPercent >= 1 && _slashPercent <= 50, "Invalid SLASH_PERCENT");
+        require(_maxDeviation >= 1 && _maxDeviation <= 100, "Invalid MAX_DEVIATION");
+        MIN_STAKE = _minStake;
+        SLASH_PERCENT = _slashPercent;
+        MAX_DEVIATION = _maxDeviation;
+    }
 
     modifier onlyPilotEscrow() {
         require(msg.sender == pilotEscrow, "Only PilotEscrow");

--- a/scripts/deploy_phase4.js
+++ b/scripts/deploy_phase4.js
@@ -9,6 +9,49 @@ const EXPECTED_CHAIN_IDS = Object.freeze({
   "base-sepolia": 84532,
 });
 
+const DEPLOY_PROFILES = Object.freeze({
+  production: {
+    requiredOracles: 5,
+    scoreQuorumPct: 50,
+    participationFloorPct: 67,
+    campaignTimeoutBlocks: 7200,
+    minStakeEth: "1.0",
+    slashPercent: 5,
+    maxDeviation: 25
+  },
+  "canary-01-5": {
+    requiredOracles: 3,
+    scoreQuorumPct: 50,
+    participationFloorPct: 67,
+    campaignTimeoutBlocks: 3600,
+    minStakeEth: "0.1",
+    slashPercent: 5,
+    maxDeviation: 25
+  },
+  solo: {
+    requiredOracles: 1,
+    scoreQuorumPct: 50,
+    participationFloorPct: 67,
+    campaignTimeoutBlocks: 1800,
+    minStakeEth: "0.05",
+    slashPercent: 5,
+    maxDeviation: 25
+  }
+});
+
+function resolveDeployProfile() {
+  const name = process.env.DEPLOY_PROFILE || process.env.CANARY_PROFILE || "production";
+  const profile = DEPLOY_PROFILES[name];
+  if (!profile) {
+    throw new Error(`Unknown deploy profile: ${name}. Valid profiles: ${Object.keys(DEPLOY_PROFILES).join(", ")}`);
+  }
+  return {
+    name,
+    ...profile,
+    minStake: hre.ethers.parseEther(profile.minStakeEth)
+  };
+}
+
 function resolveGitCommit() {
   if (process.env.GIT_COMMIT) return process.env.GIT_COMMIT;
   try {
@@ -49,6 +92,8 @@ async function readWithRetry(description, readFn, isExpected, options = {}) {
 async function main() {
   const [deployer] = await hre.ethers.getSigners();
   console.log("Deploying Phase 4 contracts with account:", deployer.address);
+  const profile = resolveDeployProfile();
+  console.log("Deploy profile:", profile.name);
   const network = await hre.ethers.provider.getNetwork();
   const chainId = Number(network.chainId);
   const expectedChainId = EXPECTED_CHAIN_IDS[hre.network.name];
@@ -59,7 +104,17 @@ async function main() {
 
   // 1. Deploy VenomRegistry
   const VenomRegistry = await hre.ethers.getContractFactory("VenomRegistry");
-  const venomRegistry = await VenomRegistry.deploy();
+  const registryConstructorArguments = [
+    profile.minStake,
+    profile.slashPercent,
+    profile.maxDeviation,
+  ];
+  const registryArtifactArguments = [
+    profile.minStake.toString(),
+    profile.slashPercent,
+    profile.maxDeviation,
+  ];
+  const venomRegistry = await VenomRegistry.deploy(...registryConstructorArguments);
   await venomRegistry.waitForDeployment();
   const venomRegistryAddress = await venomRegistry.getAddress();
   const venomRegistryTx = venomRegistry.deploymentTransaction();
@@ -67,7 +122,14 @@ async function main() {
 
   // 2. Deploy PilotEscrow (passing registry address)
   const PilotEscrow = await hre.ethers.getContractFactory("PilotEscrow");
-  const pilotEscrow = await PilotEscrow.deploy(venomRegistryAddress);
+  const escrowConstructorArguments = [
+    venomRegistryAddress,
+    profile.requiredOracles,
+    profile.scoreQuorumPct,
+    profile.participationFloorPct,
+    profile.campaignTimeoutBlocks,
+  ];
+  const pilotEscrow = await PilotEscrow.deploy(...escrowConstructorArguments);
   await pilotEscrow.waitForDeployment();
   const pilotEscrowAddress = await pilotEscrow.getAddress();
   const pilotEscrowTx = pilotEscrow.deploymentTransaction();
@@ -75,7 +137,8 @@ async function main() {
 
   // 3. Set PilotEscrow in Registry
   const bindTx = await venomRegistry.setPilotEscrow(pilotEscrowAddress);
-  const bindReceipt = await bindTx.wait(3);
+  const bindConfirmations = hre.network.name === "hardhat" ? 1 : 3;
+  const bindReceipt = await bindTx.wait(bindConfirmations);
   console.log("PilotEscrow address set in VenomRegistry");
 
   const boundEscrow = await readWithRetry(
@@ -113,6 +176,18 @@ async function main() {
     gitCommit: resolveGitCommit(),
     deployedAt: new Date().toISOString(),
     deployer: deployer.address,
+    profile: {
+      name: profile.name,
+      constants: {
+        REQUIRED_ORACLES: profile.requiredOracles,
+        SCORE_QUORUM_PCT: profile.scoreQuorumPct,
+        PARTICIPATION_FLOOR_PCT: profile.participationFloorPct,
+        CAMPAIGN_TIMEOUT_BLOCKS: profile.campaignTimeoutBlocks,
+        MIN_STAKE: profile.minStake.toString(),
+        SLASH_PERCENT: profile.slashPercent,
+        MAX_DEVIATION: profile.maxDeviation,
+      },
+    },
     owners: {
       VenomRegistry: registryOwner,
       PilotEscrow: escrowOwner,
@@ -120,12 +195,12 @@ async function main() {
     contracts: {
       VenomRegistry: {
         address: venomRegistryAddress,
-        constructorArguments: [],
+        constructorArguments: registryArtifactArguments,
         deploymentTxHash: venomRegistryTx ? venomRegistryTx.hash : null,
       },
       PilotEscrow: {
         address: pilotEscrowAddress,
-        constructorArguments: [venomRegistryAddress],
+        constructorArguments: escrowConstructorArguments,
         deploymentTxHash: pilotEscrowTx ? pilotEscrowTx.hash : null,
       },
     },
@@ -143,8 +218,8 @@ async function main() {
   fs.writeFileSync(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`);
   console.log("Deployment artifact written to:", artifactPath);
 
-  await maybeVerify(venomRegistryAddress, []);
-  await maybeVerify(pilotEscrowAddress, [venomRegistryAddress]);
+  await maybeVerify(venomRegistryAddress, registryArtifactArguments);
+  await maybeVerify(pilotEscrowAddress, escrowConstructorArguments);
 
   console.log("\n=== Phase 4 Deployment Complete ===");
   console.log("VENOM_REGISTRY_ADDRESS=", venomRegistryAddress);

--- a/test/ConfigurableConstants.test.js
+++ b/test/ConfigurableConstants.test.js
@@ -1,0 +1,122 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+const PRODUCTION_REGISTRY_ARGS = [ethers.parseEther("1.0"), 5, 25];
+const PRODUCTION_ESCROW_ARGS = [5, 50, 67, 7200];
+const CANARY_REGISTRY_ARGS = [ethers.parseEther("0.1"), 5, 25];
+const CANARY_ESCROW_ARGS = [3, 50, 67, 3600];
+
+async function deployRegistry(args = PRODUCTION_REGISTRY_ARGS) {
+  const Registry = await ethers.getContractFactory("VenomRegistry");
+  return Registry.deploy(...args);
+}
+
+async function deployEscrow(registry, args = PRODUCTION_ESCROW_ARGS) {
+  const Escrow = await ethers.getContractFactory("PilotEscrow");
+  return Escrow.deploy(await registry.getAddress(), ...args);
+}
+
+async function signEip712Score(signers, campaignUid, scores, escrowContract) {
+  const net = await ethers.provider.getNetwork();
+  const domain = {
+    name: "VENOM PilotEscrow",
+    version: "1",
+    chainId: Number(net.chainId),
+    verifyingContract: await escrowContract.getAddress()
+  };
+  const types = {
+    Score: [
+      { name: "campaignUid", type: "bytes32" },
+      { name: "score", type: "uint256" }
+    ]
+  };
+  return Promise.all(scores.map((score, index) => {
+    return signers[index].signTypedData(domain, types, { campaignUid, score });
+  }));
+}
+
+async function signEip712Abstain(signers, campaignUid, reasons, escrowContract) {
+  const net = await ethers.provider.getNetwork();
+  const domain = {
+    name: "VENOM PilotEscrow",
+    version: "1",
+    chainId: Number(net.chainId),
+    verifyingContract: await escrowContract.getAddress()
+  };
+  const types = {
+    Abstain: [
+      { name: "campaignUid", type: "bytes32" },
+      { name: "reason", type: "uint8" }
+    ]
+  };
+  return Promise.all(reasons.map((reason, index) => {
+    return signers[index].signTypedData(domain, types, { campaignUid, reason });
+  }));
+}
+
+describe("Configurable deployment constants", function () {
+  it("preserves production profile values through public getters", async function () {
+    const registry = await deployRegistry();
+    const escrow = await deployEscrow(registry);
+
+    expect(await registry.MIN_STAKE()).to.equal(ethers.parseEther("1.0"));
+    expect(await registry.SLASH_PERCENT()).to.equal(5n);
+    expect(await registry.MAX_DEVIATION()).to.equal(25n);
+    expect(await escrow.REQUIRED_ORACLES()).to.equal(5n);
+    expect(await escrow.SCORE_QUORUM_PCT()).to.equal(50n);
+    expect(await escrow.PARTICIPATION_FLOOR_PCT()).to.equal(67n);
+    expect(await escrow.CAMPAIGN_TIMEOUT_BLOCKS()).to.equal(7200n);
+  });
+
+  it("rejects invalid registry constructor constants", async function () {
+    const Registry = await ethers.getContractFactory("VenomRegistry");
+
+    await expect(Registry.deploy(ethers.parseEther("0.009"), 5, 25))
+      .to.be.revertedWith("Invalid MIN_STAKE");
+    await expect(Registry.deploy(ethers.parseEther("1.0"), 0, 25))
+      .to.be.revertedWith("Invalid SLASH_PERCENT");
+    await expect(Registry.deploy(ethers.parseEther("1.0"), 5, 0))
+      .to.be.revertedWith("Invalid MAX_DEVIATION");
+  });
+
+  it("rejects invalid escrow constructor constants", async function () {
+    const registry = await deployRegistry();
+    const Escrow = await ethers.getContractFactory("PilotEscrow");
+    const registryAddress = await registry.getAddress();
+
+    await expect(Escrow.deploy(registryAddress, 0, 50, 67, 7200))
+      .to.be.revertedWith("Invalid REQUIRED_ORACLES");
+    await expect(Escrow.deploy(registryAddress, 5, 0, 67, 7200))
+      .to.be.revertedWith("Invalid SCORE_QUORUM_PCT");
+    await expect(Escrow.deploy(registryAddress, 5, 50, 49, 7200))
+      .to.be.revertedWith("Invalid PARTICIPATION_FLOOR_PCT");
+    await expect(Escrow.deploy(registryAddress, 5, 50, 67, 99))
+      .to.be.revertedWith("Invalid CAMPAIGN_TIMEOUT_BLOCKS");
+  });
+
+  it("allows the Canary 01.5 profile to close with 3 score signers in a 5-oracle set", async function () {
+    const [owner, ...oracles] = await ethers.getSigners();
+    const registry = await deployRegistry(CANARY_REGISTRY_ARGS);
+    const escrow = await deployEscrow(registry, CANARY_ESCROW_ARGS);
+    await registry.setPilotEscrow(await escrow.getAddress());
+
+    for (let i = 0; i < 5; i++) {
+      await registry.connect(oracles[i]).registerOracle(`/ip4/127.0.0.1/tcp/50${i}`, {
+        value: ethers.parseEther("0.1")
+      });
+    }
+
+    const uid = ethers.id("canary-01-5-config");
+    const bounty = ethers.parseEther("0.01");
+    await escrow.connect(owner).fundCampaign(uid, "ipfs://canary", ethers.ZeroHash, { value: bounty });
+
+    const scores = [80, 82, 84];
+    const scoreSigs = await signEip712Score(oracles.slice(0, 3), uid, scores, escrow);
+    const reasons = [1, 1];
+    const abstainSigs = await signEip712Abstain(oracles.slice(3, 5), uid, reasons, escrow);
+
+    await expect(escrow.closeCampaign(uid, scores, scoreSigs, reasons, abstainSigs))
+      .to.emit(escrow, "CampaignClosed")
+      .withArgs(uid, owner.address, bounty, 82);
+  });
+});

--- a/test/GovernanceContracts.test.js
+++ b/test/GovernanceContracts.test.js
@@ -394,7 +394,7 @@ describe("Governance contracts", function () {
   describe("VenomRegistry", function () {
     it("tracks slashed stake separately and allows owner treasury withdrawal", async function () {
       const Registry = await ethers.getContractFactory("VenomRegistry");
-      const registry = await Registry.deploy();
+      const registry = await Registry.deploy(ethers.parseEther("1.0"), 5, 25);
       await registry.setPilotEscrow(owner.address);
 
       const stake = ethers.parseEther("1");

--- a/test/PilotEscrow.v1.1.0.test.js
+++ b/test/PilotEscrow.v1.1.0.test.js
@@ -2,16 +2,18 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 describe("PilotEscrow v1.1.0-rc.1 — Quorum & Cancellation", function () {
+    const REGISTRY_ARGS = [ethers.parseEther("1.0"), 5, 25];
+    const ESCROW_ARGS = [5, 50, 67, 7200];
     let registry, escrow, owner, attacker, oracles;
 
     beforeEach(async function () {
         [owner, attacker, ...oracles] = await ethers.getSigners(); // Hardhat provides 20 signers by default
 
         const Registry = await ethers.getContractFactory("VenomRegistry");
-        registry = await Registry.deploy();
+        registry = await Registry.deploy(...REGISTRY_ARGS);
 
         const Escrow = await ethers.getContractFactory("PilotEscrow");
-        escrow = await Escrow.deploy(await registry.getAddress());
+        escrow = await Escrow.deploy(await registry.getAddress(), ...ESCROW_ARGS);
         await registry.setPilotEscrow(await escrow.getAddress());
 
         // Register 10 active oracles for clean percentage math
@@ -104,6 +106,49 @@ describe("PilotEscrow v1.1.0-rc.1 — Quorum & Cancellation", function () {
         expect(campaign.closed).to.be.true;
     });
 
+    it("4b. Happy path accepts unsorted score arrival order and computes the median on-chain", async function () {
+        const uid = ethers.id("Q4B");
+        await escrow.connect(owner).fundCampaign(uid, "ipfs://test", ethers.id("test"), { value: ethers.parseEther("1.0") });
+
+        const scores = [90, 65, 81, 75, 70, 79];
+        const scoreSigs = await signEip712Score(oracles.slice(0, 6), uid, scores, escrow);
+        const reasons = [1];
+        const abstainSigs = await signEip712Abstain(oracles.slice(6, 7), uid, reasons, escrow);
+
+        await expect(escrow.closeCampaign(uid, scores, scoreSigs, reasons, abstainSigs))
+            .to.emit(escrow, "CampaignClosed")
+            .withArgs(uid, owner.address, ethers.parseEther("1.0"), 79);
+        expect((await escrow.campaigns(uid)).closed).to.be.true;
+    });
+
+    it("4c. closeCampaign reports and slashes score outliers beyond MAX_DEVIATION", async function () {
+        const uid = ethers.id("Q4C");
+        await escrow.connect(owner).fundCampaign(uid, "ipfs://test", ethers.id("test"), { value: ethers.parseEther("1.0") });
+
+        const scores = [70, 40, 70, 70, 70, 70];
+        const scoreSigs = await signEip712Score(oracles.slice(0, 6), uid, scores, escrow);
+        const reasons = [1];
+        const abstainSigs = await signEip712Abstain(oracles.slice(6, 7), uid, reasons, escrow);
+        const stakeBefore = (await registry.oracles(oracles[1].address)).stake;
+
+        const closeTx = escrow.closeCampaign(uid, scores, scoreSigs, reasons, abstainSigs);
+
+        await expect(closeTx)
+            .to.emit(escrow, "DeviationReported")
+            .withArgs(uid, oracles[1].address, 40, 70, 30);
+        await expect(closeTx)
+            .to.emit(registry, "OracleSlashed");
+
+        const honestOracleAfter = await registry.oracles(oracles[0].address);
+        const oracleAfter = await registry.oracles(oracles[1].address);
+        const slashAmount = (stakeBefore * 5n) / 100n;
+        expect(honestOracleAfter.active).to.be.true;
+        expect(oracleAfter.stake).to.equal(stakeBefore - slashAmount);
+        expect(oracleAfter.active).to.be.false;
+        expect(await registry.slashedStakeReserve()).to.equal(slashAmount);
+        expect(await registry.everSlashed(oracles[1].address)).to.be.true;
+    });
+
     it("5. Score-and-abstain by same oracle: abstain is dropped, score counts", async function () {
         const uid = ethers.id("Q5");
         await escrow.connect(owner).fundCampaign(uid, "ipfs://test", ethers.id("test"), { value: ethers.parseEther("1.0") });
@@ -177,7 +222,7 @@ describe("PilotEscrow v1.1.0-rc.1 — Quorum & Cancellation", function () {
 
     it("9. EIP-712 abstain replay across deployments fails", async function () {
         const Escrow = await ethers.getContractFactory("PilotEscrow");
-        const escrowB = await Escrow.deploy(await registry.getAddress());
+        const escrowB = await Escrow.deploy(await registry.getAddress(), ...ESCROW_ARGS);
 
         const uid = ethers.id("R1");
         await escrowB.connect(owner).fundCampaign(uid, "ipfs://test", ethers.id("test"), { value: ethers.parseEther("1.0") });

--- a/test/critical-fixes.test.js
+++ b/test/critical-fixes.test.js
@@ -9,16 +9,18 @@ const {
 const { isPrivateOrWildcardMultiaddr } = require("../src/utils/multiaddr");
 
 describe("VenomRegistry — Unstake, Slash, and Timelock", function () {
+    const REGISTRY_ARGS = [ethers.parseEther("1.0"), 5, 25];
+    const ESCROW_ARGS = [5, 50, 67, 7200];
     let registry, escrow, owner, oracle1, oracle2, attacker;
 
     beforeEach(async function () {
         [owner, oracle1, oracle2, attacker] = await ethers.getSigners();
 
         const Registry = await ethers.getContractFactory("VenomRegistry");
-        registry = await Registry.deploy();
+        registry = await Registry.deploy(...REGISTRY_ARGS);
 
         const Escrow = await ethers.getContractFactory("PilotEscrow");
-        escrow = await Escrow.deploy(await registry.getAddress());
+        escrow = await Escrow.deploy(await registry.getAddress(), ...ESCROW_ARGS);
         await registry.setPilotEscrow(await escrow.getAddress());
     });
 
@@ -133,10 +135,10 @@ describe("VenomRegistry — Unstake, Slash, and Timelock", function () {
     describe("PilotEscrow Timelock Upgrade", function () {
         it("sets PilotEscrow immediately on first call", async function () {
             const Registry2 = await ethers.getContractFactory("VenomRegistry");
-            const registry2 = await Registry2.deploy();
+            const registry2 = await Registry2.deploy(...REGISTRY_ARGS);
 
             const Escrow2 = await ethers.getContractFactory("PilotEscrow");
-            const escrow2 = await Escrow2.deploy(await registry2.getAddress());
+            const escrow2 = await Escrow2.deploy(await registry2.getAddress(), ...ESCROW_ARGS);
 
             expect(await registry2.pilotEscrow()).to.equal(ethers.ZeroAddress);
 
@@ -146,7 +148,7 @@ describe("VenomRegistry — Unstake, Slash, and Timelock", function () {
 
         it("schedules upgrade with 48h timelock on subsequent calls", async function () {
             const Escrow2 = await ethers.getContractFactory("PilotEscrow");
-            const escrow2 = await Escrow2.deploy(await registry.getAddress());
+            const escrow2 = await Escrow2.deploy(await registry.getAddress(), ...ESCROW_ARGS);
 
             const tx = await registry.setPilotEscrow(await escrow2.getAddress());
             const rcpt = await tx.wait();
@@ -162,7 +164,7 @@ describe("VenomRegistry — Unstake, Slash, and Timelock", function () {
 
         it("rejects executePilotEscrowUpgrade before timelock", async function () {
             const Escrow2 = await ethers.getContractFactory("PilotEscrow");
-            const escrow2 = await Escrow2.deploy(await registry.getAddress());
+            const escrow2 = await Escrow2.deploy(await registry.getAddress(), ...ESCROW_ARGS);
 
             await registry.setPilotEscrow(await escrow2.getAddress());
 
@@ -172,7 +174,7 @@ describe("VenomRegistry — Unstake, Slash, and Timelock", function () {
 
         it("executes PilotEscrow upgrade after 48h timelock", async function () {
             const Escrow2 = await ethers.getContractFactory("PilotEscrow");
-            const escrow2 = await Escrow2.deploy(await registry.getAddress());
+            const escrow2 = await Escrow2.deploy(await registry.getAddress(), ...ESCROW_ARGS);
 
             await registry.setPilotEscrow(await escrow2.getAddress());
 

--- a/test/queue.config.test.js
+++ b/test/queue.config.test.js
@@ -1,0 +1,13 @@
+const { expect } = require("chai");
+const fs = require("node:fs");
+const path = require("node:path");
+
+describe("Regression: Redis queue configuration", function () {
+  it("defaults Redis node auth to the venom_node ACL user", function () {
+    // Regression: MAIN-FIX-6
+    const text = fs.readFileSync(path.resolve(__dirname, "../aggregator/queue.js"), "utf8");
+
+    expect(text).to.include("process.env.REDIS_USERNAME || 'venom_node'");
+    expect(text).to.match(/username:\s*REDIS_USERNAME/);
+  });
+});

--- a/test/queue.isolation.test.js
+++ b/test/queue.isolation.test.js
@@ -1,0 +1,97 @@
+const { expect } = require("chai");
+const { Worker } = require("bullmq");
+const { buildQueueName } = require("../aggregator/queue");
+
+const QUEUE_MODULE = "../aggregator/queue";
+const PRODUCER_MODULE = "../aggregator/producer";
+const ENV_KEYS = ["QUEUE_NAME", "OPERATOR_QUEUE_SUFFIX", "PILOT_ESCROW_ADDRESS"];
+
+function clearRuntimeModules() {
+  for (const modulePath of [QUEUE_MODULE, PRODUCER_MODULE]) {
+    delete require.cache[require.resolve(modulePath)];
+  }
+}
+
+function withRuntimeEnv(env, assertion) {
+  const previous = {};
+  for (const key of ENV_KEYS) {
+    previous[key] = process.env[key];
+    if (Object.prototype.hasOwnProperty.call(env, key)) {
+      process.env[key] = env[key];
+    } else {
+      delete process.env[key];
+    }
+  }
+
+  clearRuntimeModules();
+  try {
+    assertion();
+  } finally {
+    clearRuntimeModules();
+    for (const key of ENV_KEYS) {
+      if (previous[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = previous[key];
+      }
+    }
+  }
+}
+
+describe("BullMQ queue isolation", function () {
+  it("preserves default shared queue names and Redis keys", function () {
+    withRuntimeEnv({
+      QUEUE_NAME: "venom-campaigns",
+      OPERATOR_QUEUE_SUFFIX: "",
+      PILOT_ESCROW_ADDRESS: "0xABCDEF"
+    }, () => {
+      const queue = require(QUEUE_MODULE);
+      const producer = require(PRODUCER_MODULE);
+
+      expect(queue.BASE_QUEUE_NAME).to.equal("venom-campaigns");
+      expect(queue.OPERATOR_QUEUE_SUFFIX).to.equal("");
+      expect(queue.QUEUE_NAME).to.equal("venom-campaigns");
+      expect(queue.operatorScopedKey("campaign", "queued", "0xabc")).to.equal("venom:campaign:queued:0xabc");
+      expect(producer.getCursorKey()).to.equal("venom:producer:lastScannedBlock:0xabcdef");
+    });
+  });
+
+  it("scopes queue names, producer cursors, and queued-campaign markers by operator suffix", function () {
+    withRuntimeEnv({
+      QUEUE_NAME: "venom-campaigns",
+      OPERATOR_QUEUE_SUFFIX: "op1",
+      PILOT_ESCROW_ADDRESS: "0xABCDEF"
+    }, () => {
+      const queue = require(QUEUE_MODULE);
+      const producer = require(PRODUCER_MODULE);
+
+      expect(queue.QUEUE_NAME).to.equal("venom-campaigns-op1");
+      expect(queue.buildQueueName("custom-queue", "op-2")).to.equal("custom-queue-op-2");
+      expect(queue.operatorScopedKey("campaign", "queued", "0xabc")).to.equal("venom:op1:campaign:queued:0xabc");
+      expect(producer.getCursorKey()).to.equal("venom:op1:producer:lastScannedBlock:0xabcdef");
+    });
+  });
+
+  it("rejects ambiguous suffixes before connecting to Redis", function () {
+    withRuntimeEnv({
+      QUEUE_NAME: "venom-campaigns",
+      OPERATOR_QUEUE_SUFFIX: "op:1",
+      PILOT_ESCROW_ADDRESS: "0xABCDEF"
+    }, () => {
+      expect(() => require(QUEUE_MODULE)).to.throw(/OPERATOR_QUEUE_SUFFIX/);
+    });
+  });
+
+  it("constructs a Worker for all valid suffixed queue names", async function () {
+    const suffixes = ["op1", "op-test", "op_test", "op.test", "OPERATOR1", "a"];
+    for (const suffix of suffixes) {
+      const name = buildQueueName("venom-campaigns", suffix);
+      const worker = new Worker(name, async () => {}, {
+        connection: { host: "127.0.0.1", port: 6379 },
+        autorun: false,
+      });
+      expect(worker.name).to.equal(name);
+      await worker.close();
+    }
+  });
+});


### PR DESCRIPTION
## [Canary 01.5] Module B: Per-operator BullMQ queue isolation

This is PR 2 of 8 in the Canary 01.5 integration series.

**Scope.** Each operator process can now run against a shared Redis instance with
isolated BullMQ queues, producer scan cursors, and queued-campaign dedup keys.
Single-operator dev mode is unchanged (no `OPERATOR_QUEUE_SUFFIX` set → unscoped
queue, unscoped Redis keys, original behavior).

**New env variables:**

- `QUEUE_NAME` (default `venom-campaigns`) — shared base name across operators
- `OPERATOR_QUEUE_SUFFIX` (default empty) — per-operator suffix, validated
  against `/^[a-zA-Z0-9._-]{1,64}$/` before any Redis connection

**Naming behavior:**

| Layer | No suffix | With suffix `op1` |
|---|---|---|
| BullMQ queue name | `venom-campaigns` | `venom-campaigns-op1` |
| Producer cursor key | `venom:producer:lastScannedBlock:<addr>` | `venom:op1:producer:lastScannedBlock:<addr>` |
| Queued-campaign dedup | `venom:campaign:queued:<uid>` | `venom:op1:campaign:queued:<uid>` |

**Why the queue uses `-` and the Redis keys use `:`.** BullMQ 5+ rejects `:` in
queue names at the Worker constructor (a stricter check than the Queue
constructor's, which accepts both). Redis itself imposes no key-separator
restriction. So the queue name uses `-` for BullMQ compatibility, while the
operator-scoped Redis keys keep `:` for readability and consistency with
existing key patterns.

This separator choice was discovered during Canary 01.5: an earlier draft used
`:` everywhere; all 5 operator containers crash-looped with
`Error: Queue name cannot contain :` 12 seconds after the first stack-up.
The fix landed before merge and is captured by the new Worker-construction
regression test.

**Tests:** 4 in `test/queue.isolation.test.js`:
- Default behavior preserved (unsuffixed → unscoped names and keys)
- Suffix scoping correct across queue + cursor + dedup keys
- Invalid suffix (e.g. `op:1`) throws **before** any Redis connection attempt
- `new Worker(name, ...)` constructs cleanly for all valid suffixes — this is
  the Bug 1 regression test; ensures a future re-introduction of the colon
  separator (or any other BullMQ-invalid character) fails CI

**Backward compatibility:** Single-operator dev mode is unaffected. Production
deployments without `OPERATOR_QUEUE_SUFFIX` set use the unscoped names exactly
as before this PR.

**Out of scope (handled in subsequent PRs):**
- `make-operator-envs.js` writes the suffix into per-operator envs → PR 3
- Canary-readiness preflight asserts suffix uniqueness → PR 4
- Module G partial's bootstrap envs (`P2P_LISTEN_PORT`, `P2P_BOOTSTRAP_PEERS`) → PR 7

**Test counts:** PR 1 baseline 78 passing → PR 2 branch _N_ passing (+_M_).

**Verification:**
- `npm run compile`: clean
- `npm test`: _N_ passing
- `node scripts/check-js.js`: clean

Refs Canary 01.5 (run window 2026-05-08), Bug 1 (MF-6).