### PR TITLE
Fix deploy bind finality regression test

### DIFF
--- a/test/deploy_phase4.test.js
+++ b/test/deploy_phase4.test.js
@@ -7,7 +7,8 @@ describe("Regression: deployment bind finality", function () {
     // Regression: MAIN-FIX-4
     const text = fs.readFileSync(path.resolve(__dirname, "../scripts/deploy_phase4.js"), "utf8");
 
-    expect(text).to.include("await bindTx.wait(3)");
+    expect(text).to.match(/const\s+bindConfirmations\s*=\s*hre\.network\.name\s*===\s*"hardhat"\s*\?\s*1\s*:\s*3\s*;/);
+    expect(text).to.match(/await\s+bindTx\.wait\(\s*bindConfirmations\s*\)/);
     expect(text).to.include("readWithRetry(");
     expect(text).to.include('"Registry PilotEscrow bind"');
   });


### PR DESCRIPTION
Match the as-merged deploy_phase4.js shape, where public-network finality is expressed through bindConfirmations before bindTx.wait().